### PR TITLE
Added GetObjectNums() for example code pdf_all_objects.go

### DIFF
--- a/pdf/contentstream/encoding.go
+++ b/pdf/contentstream/encoding.go
@@ -64,6 +64,8 @@ func newEncoderFromInlineImage(inlineImage *ContentStreamInlineImage) (StreamEnc
 		return newFlateEncoderFromInlineImage(inlineImage, nil)
 	} else if *filterName == "LZW" {
 		return newLZWEncoderFromInlineImage(inlineImage, nil)
+	} else if *filterName == "CCF" {
+		return NewCCITTFaxEncoder(), nil
 	} else {
 		common.Log.Debug("Unsupported inline image encoding filter name : %s", *filterName)
 		return nil, errors.New("Unsupported inline encoding method")

--- a/pdf/contentstream/inline-image.go
+++ b/pdf/contentstream/inline-image.go
@@ -162,11 +162,11 @@ func (this *ContentStreamInlineImage) GetColorSpace(resources *PdfPageResources)
 		return nil, errors.New("Invalid type")
 	}
 
-	if *name == "G" {
+	if *name == "G" || *name == "DeviceGray" {
 		return NewPdfColorspaceDeviceGray(), nil
-	} else if *name == "RGB" {
+	} else if *name == "RGB" || *name == "DeviceRGB" {
 		return NewPdfColorspaceDeviceRGB(), nil
-	} else if *name == "CMYK" {
+	} else if *name == "CMYK" || *name == "DeviceCMYK" {
 		return NewPdfColorspaceDeviceCMYK(), nil
 	} else if *name == "I" {
 		return nil, errors.New("Unsupported Index colorspace")

--- a/pdf/contentstream/processor.go
+++ b/pdf/contentstream/processor.go
@@ -140,6 +140,10 @@ func (csp *ContentStreamProcessor) getInitialColor(cs PdfColorspace) (PdfColor, 
 		return NewPdfColorDeviceRGB(0.0, 0.0, 0.0), nil
 	case *PdfColorspaceDeviceCMYK:
 		return NewPdfColorDeviceCMYK(0.0, 0.0, 0.0, 1.0), nil
+	case *PdfColorspaceCalGray:
+		return NewPdfColorCalGray(0.0), nil
+	case *PdfColorspaceCalRGB:
+		return NewPdfColorCalRGB(0.0, 0.0, 0.0), nil
 	case *PdfColorspaceLab:
 		l := 0.0
 		a := 0.0

--- a/pdf/core/encoding.go
+++ b/pdf/core/encoding.go
@@ -507,12 +507,19 @@ func newLZWEncoderFromStream(streamObj *PdfObjectStream, decodeParams *PdfObject
 	if decodeParams == nil {
 		obj := encDict.Get("DecodeParms")
 		if obj != nil {
-			dp, isDict := obj.(*PdfObjectDictionary)
-			if !isDict {
-				common.Log.Debug("Error: DecodeParms not a dictionary (%T)", obj)
+			if dp, isDict := obj.(*PdfObjectDictionary); isDict {
+				decodeParams = dp
+			} else if a, isArr := obj.(*PdfObjectArray); isArr {
+				if len(*a) == 1 {
+					if dp, isDict := (*a)[0].(*PdfObjectDictionary); isDict {
+						decodeParams = dp
+					}
+				}
+			}
+			if decodeParams == nil {
+				common.Log.Error("DecodeParms not a dictionary %#v", obj)
 				return nil, fmt.Errorf("Invalid DecodeParms")
 			}
-			decodeParams = dp
 		}
 	}
 

--- a/pdf/core/encoding.go
+++ b/pdf/core/encoding.go
@@ -1485,8 +1485,6 @@ func (this *RawEncoder) EncodeBytes(data []byte) ([]byte, error) {
 //
 type CCITTFaxEncoder struct{}
 
-var ErrNoCCITT = errors.New("CCITTFaxEncoder is not implemented")
-
 func NewCCITTFaxEncoder() *CCITTFaxEncoder {
 	return &CCITTFaxEncoder{}
 }
@@ -1496,28 +1494,23 @@ func (this *CCITTFaxEncoder) GetFilterName() string {
 }
 
 func (this *CCITTFaxEncoder) MakeDecodeParams() PdfObject {
-	// panic(ErrNoCCITT)
 	return nil
 }
 
 // Make a new instance of an encoding dictionary for a stream object.
 func (this *CCITTFaxEncoder) MakeStreamDict() *PdfObjectDictionary {
-	// panic(ErrNoCCITT)
 	return MakeDict()
 }
 
 func (this *CCITTFaxEncoder) DecodeBytes(encoded []byte) ([]byte, error) {
-	// panic(ErrNoCCITT)
 	return encoded, nil
 }
 
 func (this *CCITTFaxEncoder) DecodeStream(streamObj *PdfObjectStream) ([]byte, error) {
-	// panic(ErrNoCCITT)
 	return streamObj.Stream, nil
 }
 
 func (this *CCITTFaxEncoder) EncodeBytes(data []byte) ([]byte, error) {
-	// panic(ErrNoCCITT)
 	return data, nil
 }
 
@@ -1537,28 +1530,23 @@ func (this *JBIG2Encoder) GetFilterName() string {
 }
 
 func (this *JBIG2Encoder) MakeDecodeParams() PdfObject {
-	// panic(ErrNoCCITT)
 	return nil
 }
 
 // Make a new instance of an encoding dictionary for a stream object.
 func (this *JBIG2Encoder) MakeStreamDict() *PdfObjectDictionary {
-	// panic(ErrNoCCITT)
 	return MakeDict()
 }
 
 func (this *JBIG2Encoder) DecodeBytes(encoded []byte) ([]byte, error) {
-	// panic(ErrNoCCITT)
 	return encoded, nil
 }
 
 func (this *JBIG2Encoder) DecodeStream(streamObj *PdfObjectStream) ([]byte, error) {
-	// panic(ErrNoCCITT)
 	return streamObj.Stream, nil
 }
 
 func (this *JBIG2Encoder) EncodeBytes(data []byte) ([]byte, error) {
-	// panic(ErrNoCCITT)
 	return data, nil
 }
 

--- a/pdf/core/encoding_test.go
+++ b/pdf/core/encoding_test.go
@@ -70,6 +70,27 @@ func TestLZWEncoding(t *testing.T) {
 		return
 	}
 }
+// Test run length encoding.
+func TestRunLengthEncoding(t *testing.T) {
+	rawStream := []byte("this is a dummy text with some \x01\x02\x03 binary data")
+	encoder := NewRunLengthEncoder()
+	encoded, err := encoder.EncodeBytes(rawStream)
+	if err != nil {
+		t.Errorf("Failed to RunLength encode data: %v", err)
+		return
+	}
+	decoded, err := encoder.DecodeBytes(encoded)
+	if err != nil {
+		t.Errorf("Failed to RunLength decode data: %v", err)
+		return
+	}
+	if !compareSlices(decoded, rawStream) {
+		t.Errorf("Slices not matching. RunLength")
+		t.Errorf("Decoded (%d): % x", len(encoded), encoded)
+		t.Errorf("Raw     (%d): % x", len(rawStream), rawStream)
+		return
+	}
+}
 
 // Test ASCII hex encoding.
 func TestASCIIHexEncoding(t *testing.T) {

--- a/pdf/core/parser.go
+++ b/pdf/core/parser.go
@@ -673,7 +673,6 @@ func (this *PdfParser) parsePdfVersion() (int, int, error) {
 		return 0, 0, err
 	}
 
-	//version, _ := strconv.Atoi(result1[1])
 	common.Log.Debug("Pdf version %d.%d", majorVersion, minorVersion)
 
 	return int(majorVersion), int(minorVersion), nil

--- a/pdf/core/parser_test.go
+++ b/pdf/core/parser_test.go
@@ -151,7 +151,7 @@ func TestBoolParsing(t *testing.T) {
 			return
 		}
 		if bool(val) != expected {
-			t.Errorf("bool not as expected (%b)", val)
+			t.Errorf("bool not as expected (%t)", val)
 			return
 		}
 	}

--- a/pdf/core/stream.go
+++ b/pdf/core/stream.go
@@ -11,9 +11,9 @@ import (
 	"github.com/unidoc/unidoc/common"
 )
 
-// Creates the encoder from the stream's dictionary.
+// NewEncoderFromStream creates an encoder from `streamObj`'s dictionary.
 func NewEncoderFromStream(streamObj *PdfObjectStream) (StreamEncoder, error) {
-	filterObj := streamObj.PdfObjectDictionary.Get("Filter")
+	filterObj := TraceToDirectObject(streamObj.PdfObjectDictionary.Get("Filter"))
 	if filterObj == nil {
 		// No filter, return raw data back.
 		return NewRawEncoder(), nil
@@ -61,10 +61,18 @@ func NewEncoderFromStream(streamObj *PdfObjectStream) (StreamEncoder, error) {
 		return newLZWEncoderFromStream(streamObj, nil)
 	} else if *method == StreamEncodingFilterNameDCT {
 		return newDCTEncoderFromStream(streamObj, nil)
+	} else if *method == StreamEncodingFilterNameRunLength {
+		return newRunLengthEncoderFromStream(streamObj, nil)
 	} else if *method == StreamEncodingFilterNameASCIIHex {
 		return NewASCIIHexEncoder(), nil
 	} else if *method == StreamEncodingFilterNameASCII85 {
 		return NewASCII85Encoder(), nil
+	} else if *method == StreamEncodingFilterNameCCITTFax {
+		return NewCCITTFaxEncoder(), nil
+	} else if *method == StreamEncodingFilterNameJBIG2 {
+		return NewJBIG2Encoder(), nil
+	} else if *method == StreamEncodingFilterNameJPX {
+		return NewJPXEncoder(), nil
 	} else {
 		common.Log.Debug("ERROR: Unsupported encoding method!")
 		return nil, fmt.Errorf("Unsupported encoding method (%s)", *method)

--- a/pdf/core/stream.go
+++ b/pdf/core/stream.go
@@ -43,7 +43,7 @@ func NewEncoderFromStream(streamObj *PdfObjectStream) (StreamEncoder, error) {
 				return nil, err
 			}
 
-			common.Log.Trace("Multi enc: %s\n", menc)
+			common.Log.Trace("Multi enc: %s", menc)
 			return menc, nil
 		}
 

--- a/pdf/core/utils.go
+++ b/pdf/core/utils.go
@@ -38,6 +38,18 @@ func getUniDocVersion() string {
 	return common.Version
 }
 
+// GetObjectNums returns the object numbers of the PDF objects in the file
+func (this *PdfParser) GetObjectNums() (map[int]int, error) {
+	common.Log.Trace("--------GetObjectNums ----------")
+	common.Log.Trace("Xref table:")
+
+	keyObjnum := map[int]int{}
+	for k, x := range this.xrefs {
+		keyObjnum[k] = x.objectNumber
+	}
+	return keyObjnum, nil
+}
+
 /*
  * Inspect object types.
  * Go through all objects in the cross ref table and detect the types.

--- a/pdf/model/colorspace.go
+++ b/pdf/model/colorspace.go
@@ -1171,7 +1171,7 @@ func (this *PdfColorspaceCalRGB) ImageToRGB(img Image) (Image, error) {
 	maxVal := math.Pow(2, float64(img.BitsPerComponent)) - 1
 
 	rgbSamples := []uint32{}
-	for i := 0; i < len(samples); i++ {
+	for i := 0; i < len(samples)-2; i++ {
 		// A, B, C in range 0.0 to 1.0
 		aVal := float64(samples[i]) / maxVal
 		bVal := float64(samples[i+1]) / maxVal

--- a/pdf/model/colorspace.go
+++ b/pdf/model/colorspace.go
@@ -261,10 +261,6 @@ func (this *PdfColorDeviceRGB) GetNumComponents() int {
 	return 3
 }
 
-func (this *PdfColorDeviceRGB) IsColored() bool {
-	return visible(this[0]-this[1], this[0]-this[2], this[1]-this[2])
-}
-
 func (this *PdfColorDeviceRGB) R() float64 {
 	return float64(this[0])
 }
@@ -397,23 +393,6 @@ func (this *PdfColorspaceDeviceRGB) ImageToGray(img Image) (Image, error) {
 	return grayImage, nil
 }
 
-func (this *PdfColorspaceDeviceRGB) IsImageColored(img Image) bool {
-
-	samples := img.GetSamples()
-	maxVal := math.Pow(2, float64(img.BitsPerComponent)) - 1
-
-	for i := 0; i < len(samples); i += 3 {
-		// Normalized data, range 0-1.
-		r := float64(samples[i]) / maxVal
-		g := float64(samples[i+1]) / maxVal
-		b := float64(samples[i+2]) / maxVal
-		if visible(r-g, r-b, g-b) {
-			return true
-		}
-	}
-	return false
-}
-
 //////////////////////
 // DeviceCMYK
 // C, M, Y, K components.
@@ -429,10 +408,6 @@ func NewPdfColorDeviceCMYK(c, m, y, k float64) *PdfColorDeviceCMYK {
 
 func (this *PdfColorDeviceCMYK) GetNumComponents() int {
 	return 4
-}
-
-func (this *PdfColorDeviceCMYK) IsColored() bool {
-	return visible(this[0]-this[1], this[0]-this[2], this[1]-this[2])
 }
 
 func (this *PdfColorDeviceCMYK) C() float64 {
@@ -622,10 +597,6 @@ func (this *PdfColorCalGray) GetNumComponents() int {
 	return 1
 }
 
-func (this *PdfColorCalGray) IsColored() bool {
-	return false
-}
-
 func (this *PdfColorCalGray) Val() float64 {
 	return float64(*this)
 }
@@ -793,7 +764,6 @@ func (this *PdfColorspaceCalGray) ColorFromFloats(vals []float64) (PdfColor, err
 
 func (this *PdfColorspaceCalGray) ColorFromPdfObjects(objects []PdfObject) (PdfColor, error) {
 	if len(objects) != 1 {
-		common.Log.Error("len(objects)=%d. Should be 1. objects=%#v", len(objects), objects)
 		return nil, errors.New("Range check")
 	}
 
@@ -889,10 +859,6 @@ func NewPdfColorCalRGB(a, b, c float64) *PdfColorCalRGB {
 
 func (this *PdfColorCalRGB) GetNumComponents() int {
 	return 3
-}
-
-func (this *PdfColorCalRGB) IsColored() bool {
-	return visible(this[0]-this[1], this[0]-this[2], this[1]-this[2])
 }
 
 func (this *PdfColorCalRGB) A() float64 {
@@ -1221,10 +1187,6 @@ func NewPdfColorLab(l, a, b float64) *PdfColorLab {
 
 func (this *PdfColorLab) GetNumComponents() int {
 	return 3
-}
-
-func (this *PdfColorLab) IsColored() bool {
-	return visible(this[1], this[2])
 }
 
 func (this *PdfColorLab) L() float64 {
@@ -2695,19 +2657,4 @@ func (this *PdfColorspaceDeviceNAttributes) ToPdfObject() PdfObject {
 	}
 
 	return dict
-}
-
-// ColorTolerance is the smallest color component that is visible on a typical mid-range color laser printer
-// cpts have values in range 0.0-1.0
-const ColorTolerance = 0.5 / 255.0
-
-// visible returns true if any of color component `cpts` is visible on a typical mid-range color laser printer
-// cpts have values in range 0.0-1.0
-func visible(cpts ...float64) bool {
-	for _, x := range cpts {
-		if math.Abs(x) > ColorTolerance {
-			return true
-		}
-	}
-	return false
 }

--- a/pdf/model/page.go
+++ b/pdf/model/page.go
@@ -400,6 +400,11 @@ func (this *PdfPage) GetMediaBox() (*PdfRectangle, error) {
 	return nil, errors.New("Media box not defined")
 }
 
+// GetResources returns the inheritable resources, either from the page or or a higher up page/pages struct.
+func (this *PdfPage) GetResources() (*PdfPageResources, error) {
+	return this.getResources()
+}
+
 // Get the inheritable resources, either from the page or or a higher up page/pages struct.
 func (this *PdfPage) getResources() (*PdfPageResources, error) {
 	if this.Resources != nil {

--- a/pdf/model/reader.go
+++ b/pdf/model/reader.go
@@ -756,7 +756,14 @@ func (this *PdfReader) Inspect() (map[string]int, error) {
 	return this.parser.Inspect()
 }
 
-// Get specific object number.
+// GetObjectNums returns the object numbers of the PDF objects in the file
+// e.g. keyNum, _ := pdfReader.GetObjectNums()
+//      keyNum[k] is object number of  pdfReader.GetIndirectObjectByNumber(k)
+func (this *PdfReader) GetObjectNums() (map[int]int, error) {
+	return this.parser.GetObjectNums()
+}
+
+// GetIndirectObjectByNumber returns PDF objects by number.
 func (this *PdfReader) GetIndirectObjectByNumber(number int) (PdfObject, error) {
 	obj, err := this.parser.LookupByNumber(number)
 	return obj, err

--- a/pdf/model/resources.go
+++ b/pdf/model/resources.go
@@ -326,7 +326,7 @@ func (r *PdfPageResources) GetXObjectByName(keyName PdfObjectName) (*PdfObjectSt
 		}
 		dict := stream.PdfObjectDictionary
 
-		name, ok := dict.Get("Subtype").(*PdfObjectName)
+		name, ok := TraceToDirectObject(dict.Get("Subtype")).(*PdfObjectName)
 		if !ok {
 			common.Log.Debug("XObject Subtype not a Name, dict: %s", dict.String())
 			return nil, XObjectTypeUndefined

--- a/pdf/model/xobject.go
+++ b/pdf/model/xobject.go
@@ -300,7 +300,7 @@ func NewXObjectImageFromStream(stream *PdfObjectStream) (*XObjectImage, error) {
 	}
 	img.Filter = encoder
 
-	if obj := dict.Get("Width"); obj != nil {
+	if obj := TraceToDirectObject(dict.Get("Width")); obj != nil {
 		iObj, ok := obj.(*PdfObjectInteger)
 		if !ok {
 			return nil, errors.New("Invalid image width object")
@@ -311,7 +311,7 @@ func NewXObjectImageFromStream(stream *PdfObjectStream) (*XObjectImage, error) {
 		return nil, errors.New("Width missing")
 	}
 
-	if obj := dict.Get("Height"); obj != nil {
+	if obj := TraceToDirectObject(dict.Get("Height")); obj != nil {
 		iObj, ok := obj.(*PdfObjectInteger)
 		if !ok {
 			return nil, errors.New("Invalid image height object")
@@ -322,7 +322,7 @@ func NewXObjectImageFromStream(stream *PdfObjectStream) (*XObjectImage, error) {
 		return nil, errors.New("Height missing")
 	}
 
-	if obj := dict.Get("ColorSpace"); obj != nil {
+	if obj := TraceToDirectObject(dict.Get("ColorSpace")); obj != nil {
 		cs, err := newPdfColorspaceFromPdfObject(obj)
 		if err != nil {
 			return nil, err
@@ -334,7 +334,7 @@ func NewXObjectImageFromStream(stream *PdfObjectStream) (*XObjectImage, error) {
 		img.ColorSpace = NewPdfColorspaceDeviceGray()
 	}
 
-	if obj := dict.Get("BitsPerComponent"); obj != nil {
+	if obj := TraceToDirectObject(dict.Get("BitsPerComponent")); obj != nil {
 		iObj, ok := obj.(*PdfObjectInteger)
 		if !ok {
 			return nil, errors.New("Invalid image height object")


### PR DESCRIPTION
This enables example pdf_all_objects.go

I use pdf_all_objects.go in my unidoc development. It it a quick way to print the contents of a PDF file