### PR TITLE
Fixed some bugs found while getting pdf_descibe.go to work

### DIFF
--- a/pdf/contentstream/inline-image.go
+++ b/pdf/contentstream/inline-image.go
@@ -162,11 +162,11 @@ func (this *ContentStreamInlineImage) GetColorSpace(resources *PdfPageResources)
 		return nil, errors.New("Invalid type")
 	}
 
-	if *name == "G" {
+	if *name == "G" || *name == "DeviceGray" {
 		return NewPdfColorspaceDeviceGray(), nil
-	} else if *name == "RGB" {
+	} else if *name == "RGB" || *name == "DeviceRGB" {
 		return NewPdfColorspaceDeviceRGB(), nil
-	} else if *name == "CMYK" {
+	} else if *name == "CMYK" || *name == "DeviceCMYK" {
 		return NewPdfColorspaceDeviceCMYK(), nil
 	} else if *name == "I" {
 		return nil, errors.New("Unsupported Index colorspace")

--- a/pdf/contentstream/processor.go
+++ b/pdf/contentstream/processor.go
@@ -140,6 +140,10 @@ func (csp *ContentStreamProcessor) getInitialColor(cs PdfColorspace) (PdfColor, 
 		return NewPdfColorDeviceRGB(0.0, 0.0, 0.0), nil
 	case *PdfColorspaceDeviceCMYK:
 		return NewPdfColorDeviceCMYK(0.0, 0.0, 0.0, 1.0), nil
+	case *PdfColorspaceCalGray:
+		return NewPdfColorCalGray(0.0), nil
+	case *PdfColorspaceCalRGB:
+		return NewPdfColorCalRGB(0.0, 0.0, 0.0), nil
 	case *PdfColorspaceLab:
 		l := 0.0
 		a := 0.0

--- a/pdf/core/encoding_test.go
+++ b/pdf/core/encoding_test.go
@@ -70,6 +70,27 @@ func TestLZWEncoding(t *testing.T) {
 		return
 	}
 }
+// Test run length encoding.
+func TestRunLengthEncoding(t *testing.T) {
+	rawStream := []byte("this is a dummy text with some \x01\x02\x03 binary data")
+	encoder := NewRunLengthEncoder()
+	encoded, err := encoder.EncodeBytes(rawStream)
+	if err != nil {
+		t.Errorf("Failed to RunLength encode data: %v", err)
+		return
+	}
+	decoded, err := encoder.DecodeBytes(encoded)
+	if err != nil {
+		t.Errorf("Failed to RunLength decode data: %v", err)
+		return
+	}
+	if !compareSlices(decoded, rawStream) {
+		t.Errorf("Slices not matching. RunLength")
+		t.Errorf("Decoded (%d): % x", len(encoded), encoded)
+		t.Errorf("Raw     (%d): % x", len(rawStream), rawStream)
+		return
+	}
+}
 
 // Test ASCII hex encoding.
 func TestASCIIHexEncoding(t *testing.T) {

--- a/pdf/core/parser_test.go
+++ b/pdf/core/parser_test.go
@@ -151,7 +151,7 @@ func TestBoolParsing(t *testing.T) {
 			return
 		}
 		if bool(val) != expected {
-			t.Errorf("bool not as expected (%b)", val)
+			t.Errorf("bool not as expected (%t)", val)
 			return
 		}
 	}

--- a/pdf/core/stream.go
+++ b/pdf/core/stream.go
@@ -13,7 +13,7 @@ import (
 
 // NewEncoderFromStream creates a StreamEncoder based on the stream's dictionary.
 func NewEncoderFromStream(streamObj *PdfObjectStream) (StreamEncoder, error) {
-	filterObj := streamObj.PdfObjectDictionary.Get("Filter")
+	filterObj := TraceToDirectObject(streamObj.PdfObjectDictionary.Get("Filter"))
 	if filterObj == nil {
 		// No filter, return raw data back.
 		return NewRawEncoder(), nil
@@ -61,6 +61,8 @@ func NewEncoderFromStream(streamObj *PdfObjectStream) (StreamEncoder, error) {
 		return newLZWEncoderFromStream(streamObj, nil)
 	} else if *method == StreamEncodingFilterNameDCT {
 		return newDCTEncoderFromStream(streamObj, nil)
+	} else if *method == StreamEncodingFilterNameRunLength {
+		return newRunLengthEncoderFromStream(streamObj, nil)
 	} else if *method == StreamEncodingFilterNameASCIIHex {
 		return NewASCIIHexEncoder(), nil
 	} else if *method == StreamEncodingFilterNameASCII85 {

--- a/pdf/model/colorspace.go
+++ b/pdf/model/colorspace.go
@@ -590,7 +590,7 @@ func (this *PdfColorspaceDeviceCMYK) ImageToRGB(img Image) (Image, error) {
 		decode = []float64{0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0}
 	}
 	if len(decode) != 8 {
-		common.Log.Debug("Invalid decode array (%d): % d", len(decode), decode)
+		common.Log.Debug("Invalid decode array (%d): % .3f", len(decode), decode)
 		return img, errors.New("Invalid decode array")
 	}
 	common.Log.Trace("Decode array: % f", decode)
@@ -809,7 +809,7 @@ func (this *PdfColorspaceCalGray) ColorFromFloats(vals []float64) (PdfColor, err
 }
 
 func (this *PdfColorspaceCalGray) ColorFromPdfObjects(objects []PdfObject) (PdfColor, error) {
-	if len(objects) != 4 {
+	if len(objects) != 1 {
 		return nil, errors.New("Range check")
 	}
 
@@ -953,7 +953,7 @@ func (this *PdfColorspaceCalRGB) String() string {
 }
 
 func (this *PdfColorspaceCalRGB) GetNumComponents() int {
-	return 1
+	return 3
 }
 
 func newPdfColorspaceCalRGBFromPdfObject(obj PdfObject) (*PdfColorspaceCalRGB, error) {
@@ -1183,7 +1183,7 @@ func (this *PdfColorspaceCalRGB) ImageToRGB(img Image) (Image, error) {
 	maxVal := math.Pow(2, float64(img.BitsPerComponent)) - 1
 
 	rgbSamples := []uint32{}
-	for i := 0; i < len(samples); i++ {
+	for i := 0; i < len(samples)-2; i++ {
 		// A, B, C in range 0.0 to 1.0
 		aVal := float64(samples[i]) / maxVal
 		bVal := float64(samples[i+1]) / maxVal

--- a/pdf/model/resources.go
+++ b/pdf/model/resources.go
@@ -138,7 +138,7 @@ func (r *PdfPageResources) GetShadingByName(keyName PdfObjectName) (*PdfShading,
 		return nil, false
 	}
 
-	shadingDict, ok := r.Shading.(*PdfObjectDictionary)
+	shadingDict, ok := TraceToDirectObject(r.Shading).(*PdfObjectDictionary)
 	if !ok {
 		common.Log.Debug("ERROR: Invalid Shading entry - not a dict (got %T)", r.Shading)
 		return nil, false
@@ -178,7 +178,7 @@ func (r *PdfPageResources) GetPatternByName(keyName PdfObjectName) (*PdfPattern,
 		return nil, false
 	}
 
-	patternDict, ok := r.Pattern.(*PdfObjectDictionary)
+	patternDict, ok := TraceToDirectObject(r.Pattern).(*PdfObjectDictionary)
 	if !ok {
 		common.Log.Debug("ERROR: Invalid Pattern entry - not a dict (got %T)", r.Pattern)
 		return nil, false
@@ -326,7 +326,7 @@ func (r *PdfPageResources) GetXObjectByName(keyName PdfObjectName) (*PdfObjectSt
 		}
 		dict := stream.PdfObjectDictionary
 
-		name, ok := dict.Get("Subtype").(*PdfObjectName)
+		name, ok := TraceToDirectObject(dict.Get("Subtype")).(*PdfObjectName)
 		if !ok {
 			common.Log.Debug("XObject Subtype not a Name, dict: %s", dict.String())
 			return nil, XObjectTypeUndefined

--- a/pdf/model/xobject.go
+++ b/pdf/model/xobject.go
@@ -300,7 +300,7 @@ func NewXObjectImageFromStream(stream *PdfObjectStream) (*XObjectImage, error) {
 	}
 	img.Filter = encoder
 
-	if obj := dict.Get("Width"); obj != nil {
+	if obj := TraceToDirectObject(dict.Get("Width")); obj != nil {
 		iObj, ok := obj.(*PdfObjectInteger)
 		if !ok {
 			return nil, errors.New("Invalid image width object")
@@ -311,7 +311,7 @@ func NewXObjectImageFromStream(stream *PdfObjectStream) (*XObjectImage, error) {
 		return nil, errors.New("Width missing")
 	}
 
-	if obj := dict.Get("Height"); obj != nil {
+	if obj := TraceToDirectObject(dict.Get("Height")); obj != nil {
 		iObj, ok := obj.(*PdfObjectInteger)
 		if !ok {
 			return nil, errors.New("Invalid image height object")
@@ -322,7 +322,7 @@ func NewXObjectImageFromStream(stream *PdfObjectStream) (*XObjectImage, error) {
 		return nil, errors.New("Height missing")
 	}
 
-	if obj := dict.Get("ColorSpace"); obj != nil {
+	if obj := TraceToDirectObject(dict.Get("ColorSpace")); obj != nil {
 		cs, err := newPdfColorspaceFromPdfObject(obj)
 		if err != nil {
 			return nil, err
@@ -334,7 +334,7 @@ func NewXObjectImageFromStream(stream *PdfObjectStream) (*XObjectImage, error) {
 		img.ColorSpace = NewPdfColorspaceDeviceGray()
 	}
 
-	if obj := dict.Get("BitsPerComponent"); obj != nil {
+	if obj := TraceToDirectObject(dict.Get("BitsPerComponent")); obj != nil {
 		iObj, ok := obj.(*PdfObjectInteger)
 		if !ok {
 			return nil, errors.New("Invalid image height object")


### PR DESCRIPTION
This is a cleaned up version of https://github.com/unidoc/unidoc/pull/93

Changes needed to make pdf_describe.go example work
Extract decodeParam when they are in a 1-element array
Changes to make shamirturing.pdf pass pdf_describe.go
Fixed a buffer overrun seen in my testing on ESCP-R reference_151008
Changes to make a_im_nomask.pdf pass pdf_describe.go 
Changes to make shattered-1.pdf pass pdf_describe.go 
Changes to make 1986-jacm.pdf pass pdf_describe.go 
 Added a run length encode filter 

