### PR TITLE
Text wrapping : dont encode p.textLines

### DIFF
--- a/pdf/creator/paragraph.go
+++ b/pdf/creator/paragraph.go
@@ -223,7 +223,7 @@ func (p *Paragraph) getTextWidth() float64 {
 // XXX/TODO: Consider the Knuth/Plass algorithm or an alternative.
 func (p *Paragraph) wrapText() error {
 	if !p.enableWrap {
-		p.textLines = []string{p.encoder.Encode(p.text)}
+		p.textLines = []string{p.text}
 		return nil
 	}
 


### PR DESCRIPTION
The content of the struct field Paragraph.textLines must be not encoded with the text encoder because after the method drawParagraphOnBlock encodes it again.

It is useless to say that twice encoding on the same text portion gives troubles :)

Illustration of the issue : 

```go
package main

import (
	"io/ioutil"
	"os"

	"fmt"

	"github.com/unidoc/unidoc/common"
	"github.com/unidoc/unidoc/pdf/creator"
)

func main() {

	f, err := ioutil.TempFile(os.TempDir(), "pdf")
	if err != nil {
		panic(err)
	}

	common.SetLogger(common.NewConsoleLogger(common.LogLevelDebug))

	c := creator.New()
	t := creator.NewTable(1)
	cell := t.NewCell()
	cell.SetContent(creator.NewParagraph("this is a special char ß"))
	err = c.Draw(t)
	if err != nil {
		panic(err)
	}

	err = c.Write(f)
	if err != nil {
		panic(err)
	}

	fmt.Println(f.Name())
}
```

Gives this result without the patch : 

```
$ go run test.go                 
[DEBUG]  paragraph.go:412 Rune 0xfffd not supported by text encoder
[DEBUG]  paragraph.go:348 ERROR: Unsupported rune in text encoding
[DEBUG]  table.go:293 Error: Unsupported rune in text encoding

```