### PR TITLE
Insert a space when TJ string is offset by more than a threshold

### DIFF
--- a/pdf/contentstream/contentstream.go
+++ b/pdf/contentstream/contentstream.go
@@ -131,8 +131,17 @@ func (this *ContentStreamParser) ExtractText() (string, error) {
 				return "", fmt.Errorf("Invalid parameter type, no array (%T)", op.Params[0])
 			}
 			for _, obj := range *paramList {
-				if strObj, ok := obj.(*PdfObjectString); ok {
-					txt += string(*strObj)
+				switch v := obj.(type) {
+				case *PdfObjectString:
+					txt += string(*v)
+				case *PdfObjectFloat:
+					if *v < -100 {
+						txt += " "
+					}
+				case *PdfObjectInteger:
+					if *v < -100 {
+						txt += " "
+					}
 				}
 			}
 		} else if inText && op.Operand == "Tj" {

--- a/pdf/contentstream/contentstream_test.go
+++ b/pdf/contentstream/contentstream_test.go
@@ -1,0 +1,25 @@
+package contentstream
+
+import (
+	"testing"
+)
+
+func TestOperandTJSpacing(t *testing.T) {
+
+	content := `BT
+	[(are)-328(h)5(ypothesized)-328(to)-327(in\003uence)-328(the)-328(stability)-328(of)-328(the)-328(upstream)-327(glaciers,)-328(and)-328(thus)-328(of)-328(the)-328(entire)-327(ice)-328(sheet)]TJ
+	ET`
+	referenceText := "are hypothesized to in\003uence the stability of the upstream glaciers, and thus of the entire ice sheet"
+
+	cStreamParser := NewContentStreamParser(content)
+
+	text, err := cStreamParser.ExtractText()
+	if err != nil {
+		t.Error()
+	}
+
+	if text != referenceText {
+		t.Fail()
+	}
+
+}


### PR DESCRIPTION
When text is part of a `TJ` operand, `ContentStream.ExtractText` concatenates all of the `PDFObjectString`s that it finds. However, the `TJ` operator may perform glyph positioning, and ignoring this positioning results in spaces being ignored. For example, see the output of the text extraction example program at https://unidoc.io/examples/text/extract-text-in-pdf when applied to the paper https://research.google.com/pubs/pub43146.html.

This implements a simple way to handle glyph positioning inserting a space when the offset exceeds a hard-coded amount.

Is there a way to do this considering previous `Tc` and `Tw` operators?