### PR TITLE
Added SetForms to Creator, giving the ability to fill in form fields

### DIFF
--- a/pdf/creator/creator.go
+++ b/pdf/creator/creator.go
@@ -41,6 +41,15 @@ type Creator struct {
 	finalized bool
 
 	toc *TableOfContents
+
+	// Forms.
+	acroForm *model.PdfAcroForm
+}
+
+// SetForms Add Acroforms to a PDF file.  Sets the specified form for writing.
+func (c *Creator) SetForms(form *model.PdfAcroForm) error {
+	c.acroForm = form
+	return nil
 }
 
 // FrontpageFunctionArgs holds the input arguments to a front page drawing function.
@@ -453,6 +462,14 @@ func (c *Creator) Write(ws io.WriteSeeker) error {
 	}
 
 	pdfWriter := model.NewPdfWriter()
+	// Form fields.
+	if c.acroForm != nil {
+		errF := pdfWriter.SetForms(c.acroForm)
+		if errF != nil {
+			common.Log.Debug("Failure: %v", errF)
+			return errF
+		}
+	}
 
 	// Pdf Writer access hook.  Can be used to encrypt, etc. via the PdfWriter instance.
 	if c.pdfWriterAccessFunc != nil {


### PR DESCRIPTION
There was no obvious way to pass a populated PdfAcroForm to the underlying PdfWriter.  This code adds acroForm *model.PdfAcroForm and SetForms to Creator.  

Populating the PdfAcroForm is left to the user to implement.  But once populated, this enhancement allows you to write the PDF with the form fields filled in.