### PR TITLE
Fix #131: Return error on pageNumber = 0

### DIFF
--- a/pdf/model/reader.go
+++ b/pdf/model/reader.go
@@ -724,7 +724,11 @@ func (this *PdfReader) GetPage(pageNumber int) (*PdfPage, error) {
 	if len(this.pageList) < pageNumber {
 		return nil, errors.New("Invalid page number (page count too short)")
 	}
-	page := this.PageList[pageNumber-1]
+	idx := pageNumber - 1
+	if idx < 0 {
+		return nil, fmt.Errorf("Page numbering must start at 1")
+	}
+	page := this.PageList[idx]
 
 	return page, nil
 }


### PR DESCRIPTION
I chose to return an error if the user passes pageNumber = 0 to prevent a panic.  However, it may be more intuitive to start the page numbers from 0.