### PR TITLE
bugfix for cal code val

### DIFF
--- a/pdf/internal/cmap/utils.go
+++ b/pdf/internal/cmap/utils.go
@@ -23,8 +23,8 @@ func hexToString(shex cmapHexString) string {
 
 	// Assumes unicode in format <HHLL> with 2 bytes HH and LL representing a rune.
 	for i := 0; i < len(shex.b)-1; i += 2 {
-		b1 := shex.b[i]
-		b2 := shex.b[i+1]
+		b1 := uint64(shex.b[i])
+		b2 := uint64(shex.b[i+1])
 		r := rune((b1 << 8) | b2)
 
 		buf.WriteRune(r)


### PR DESCRIPTION
when not use uint64 to change, the val calculated will not be correct which make the map of cmap failed