### PR TITLE
bugfix for parse

### DIFF
--- a/pdf/internal/cmap/cmap.go
+++ b/pdf/internal/cmap/cmap.go
@@ -65,6 +65,8 @@ func (cmap *CMap) CharcodeBytesToUnicode(src []byte) string {
 			if has {
 				buf.WriteString(tgt)
 				break
+			} else if j == maxLen-1 || i+j == len(src)-1 {
+				break
 			}
 		}
 		i += j + 1


### PR DESCRIPTION
when j reach to MaxLen or len(src) to jump, it will jump one more character which affect the parse afterward