### PR TITLE
Creator tablecell div image support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
         sh 'go version'
 
         stage('Checkout') {
-            git url: 'https://github.com/unidoc/unidoc.git'
+            checkout scm
         }
 
         stage('Prepare') {

--- a/pdf/creator/block.go
+++ b/pdf/creator/block.go
@@ -96,7 +96,7 @@ func (blk *Block) SetAngle(angleDeg float64) {
 	blk.angle = angleDeg
 }
 
-// Duplicate the block with a new copy of the operations list.
+// duplicate duplicates the block with a new copy of the operations list.
 func (blk *Block) duplicate() *Block {
 	dup := &Block{}
 
@@ -167,7 +167,7 @@ func (blk *Block) Width() float64 {
 	return blk.width
 }
 
-// Add contents to a block.  Wrap both existing and new contents to ensure
+// addContents adds contents to a block.  Wrap both existing and new contents to ensure
 // independence of content operations.
 func (blk *Block) addContents(operations *contentstream.ContentStreamOperations) {
 	blk.contents.WrapIfNeeded()
@@ -175,7 +175,7 @@ func (blk *Block) addContents(operations *contentstream.ContentStreamOperations)
 	*blk.contents = append(*blk.contents, *operations...)
 }
 
-// Add contents to a block by contents string.
+// addContentsByString adds contents to a block by contents string.
 func (blk *Block) addContentsByString(contents string) error {
 	cc := contentstream.NewContentStreamParser(contents)
 	operations, err := cc.Parse()
@@ -235,7 +235,7 @@ func (blk *Block) ScaleToHeight(h float64) {
 	blk.Scale(ratio, ratio)
 }
 
-// Internal function to apply translation to the block, moving block contents on the PDF.
+// translate translates the block, moving block contents on the PDF. For internal use.
 func (blk *Block) translate(tx, ty float64) {
 	ops := contentstream.NewContentCreator().
 		Translate(tx, -ty).
@@ -245,7 +245,8 @@ func (blk *Block) translate(tx, ty float64) {
 	blk.contents.WrapIfNeeded()
 }
 
-// Draw the block on a Page.
+// drawToPage draws the block on a PdfPage. Generates the content streams and appends to the PdfPage's content
+// stream and links needed resources.
 func (blk *Block) drawToPage(page *model.PdfPage) error {
 	// Check if Page contents are wrapped - if not wrap it.
 	content, err := page.GetAllContentStreams()
@@ -279,7 +280,7 @@ func (blk *Block) drawToPage(page *model.PdfPage) error {
 	return nil
 }
 
-// Draw the drawable d on the block.
+// Draw draws the drawable d on the block.
 // Note that the drawable must not wrap, i.e. only return one block. Otherwise an error is returned.
 func (blk *Block) Draw(d Drawable) error {
 	ctx := DrawContext{}
@@ -330,13 +331,13 @@ func (blk *Block) DrawWithContext(d Drawable, ctx DrawContext) error {
 	return nil
 }
 
-// Append another block onto the block.
+// mergeBlocks appends another block onto the block.
 func (blk *Block) mergeBlocks(toAdd *Block) error {
 	err := mergeContents(blk.contents, blk.resources, toAdd.contents, toAdd.resources)
 	return err
 }
 
-// Merge contents and content streams.
+// mergeContents merges contents and content streams.
 // Active in the sense that it modified the input contents and resources.
 func mergeContents(contents *contentstream.ContentStreamOperations, resources *model.PdfPageResources,
 	contentsToAdd *contentstream.ContentStreamOperations, resourcesToAdd *model.PdfPageResources) error {

--- a/pdf/creator/block.go
+++ b/pdf/creator/block.go
@@ -130,6 +130,7 @@ func (blk *Block) GeneratePageBlocks(ctx DrawContext) ([]*Block, DrawContext, er
 			cc.Translate(0, -blk.Height())
 		}
 		contents := append(*cc.Operations(), *dup.contents...)
+		contents.WrapIfNeeded()
 		dup.contents = &contents
 
 		blocks = append(blocks, dup)

--- a/pdf/creator/creator.go
+++ b/pdf/creator/creator.go
@@ -189,7 +189,7 @@ func (c *Creator) newPage() *model.PdfPage {
 	width := c.pagesize[0]
 	height := c.pagesize[1]
 
-	bbox := model.PdfRectangle{0, 0, width, height}
+	bbox := model.PdfRectangle{Llx: 0, Lly: 0, Urx: width, Ury: height}
 	page.MediaBox = &bbox
 
 	c.pageWidth = width

--- a/pdf/creator/division.go
+++ b/pdf/creator/division.go
@@ -1,0 +1,136 @@
+/*
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.md', which is part of this source code package.
+ */
+
+package creator
+
+import (
+	"errors"
+
+	"github.com/unidoc/unidoc/common"
+)
+
+// Division is a container component which can wrap across multiple pages (unlike Block).
+// It can contain multiple Drawable components (currently supporting Paragraph and Image).
+//
+// The component stacking behavior is vertical, where the Drawables are drawn on top of each other.
+// TODO: Add inline mode (horizontal stacking).
+type Division struct {
+	components []VectorDrawable
+
+	// Positioning: relative / absolute.
+	positioning positioning
+
+	// Margins to be applied around the block when drawing on Page.
+	margins margins
+}
+
+// NewDivision returns a new Division container component.
+func NewDivision() *Division {
+	div := &Division{}
+	div.components = []VectorDrawable{}
+	return div
+}
+
+// Add adds a VectorDrawable to the Division container.
+// Currently supported VectorDrawables: *Paragraph, *Image.
+func (div *Division) Add(d VectorDrawable) error {
+	supported := false
+
+	switch d.(type) {
+	case *Paragraph:
+		supported = true
+	case *Image:
+		supported = true
+	}
+
+	if !supported {
+		return errors.New("Unsupported type in Division")
+	}
+
+	div.components = append(div.components, d)
+
+	return nil
+}
+
+// Height returns the height for the Division component assuming all stacked on top of each other.
+func (div *Division) Height() float64 {
+	y := 0.0
+	yMax := 0.0
+	for _, component := range div.components {
+		compWidth, compHeight := component.Width(), component.Height()
+		switch t := component.(type) {
+		case *Paragraph:
+			p := t
+			compWidth += p.margins.left + p.margins.right
+			compHeight += p.margins.top + p.margins.bottom
+		}
+
+		// Vertical stacking.
+		y += compHeight
+		yMax = y
+	}
+
+	return yMax
+}
+
+// Width is not used. Not used as a Division element is designed to fill into available width depending on
+// context.  Returns 0.
+func (div *Division) Width() float64 {
+	return 0
+}
+
+// GeneratePageBlocks generates the page blocks for the Division component.
+// Multiple blocks are generated if the contents wrap over multiple pages.
+func (div *Division) GeneratePageBlocks(ctx DrawContext) ([]*Block, DrawContext, error) {
+	pageblocks := []*Block{}
+
+	origCtx := ctx
+
+	if div.positioning.isRelative() {
+		// Update context.
+		ctx.X += div.margins.left
+		ctx.Y += div.margins.top
+		ctx.Width -= div.margins.left + div.margins.right
+		ctx.Height -= div.margins.top
+	}
+
+	// Draw.
+	for _, component := range div.components {
+		newblocks, updCtx, err := component.GeneratePageBlocks(ctx)
+		if err != nil {
+			common.Log.Debug("Error generating page blocks: %v", err)
+			return nil, ctx, err
+		}
+
+		if len(newblocks) < 1 {
+			continue
+		}
+
+		if len(pageblocks) > 0 {
+			// If there are pageblocks already in place.
+			// merge the first block in with current Block and append the rest.
+			pageblocks[len(pageblocks)-1].mergeBlocks(newblocks[0])
+			pageblocks = append(pageblocks, newblocks[1:]...)
+		} else {
+			pageblocks = append(pageblocks, newblocks[0:]...)
+		}
+
+		// Apply padding/margins.
+		updCtx.X = ctx.X
+		ctx = updCtx
+	}
+
+	if div.positioning.isRelative() {
+		// Move back X to same start of line.
+		ctx.X = origCtx.X
+	}
+
+	if div.positioning.isAbsolute() {
+		// If absolute: return original context.
+		return pageblocks, origCtx, nil
+	}
+
+	return pageblocks, ctx, nil
+}

--- a/pdf/creator/drawable.go
+++ b/pdf/creator/drawable.go
@@ -16,7 +16,11 @@ type Drawable interface {
 // VectorDrawable is a Drawable with a specified width and height.
 type VectorDrawable interface {
 	Drawable
+
+	// Width returns the width of the Drawable.
 	Width() float64
+
+	// Height returns the height of the Drawable.
 	Height() float64
 }
 
@@ -30,7 +34,7 @@ type DrawContext struct {
 	// Current position.  In a relative positioning mode, a drawable will be placed at these coordinates.
 	X, Y float64
 
-	// Context dimensions.  Available width and height.
+	// Context dimensions.  Available width and height (on current page).
 	Width, Height float64
 
 	// Page Margins.

--- a/pdf/creator/filled_curve.go
+++ b/pdf/creator/filled_curve.go
@@ -30,38 +30,38 @@ func NewFilledCurve() *FilledCurve {
 }
 
 // AppendCurve appends a Bezier curve to the filled curve.
-func (this *FilledCurve) AppendCurve(curve draw.CubicBezierCurve) *FilledCurve {
-	this.curves = append(this.curves, curve)
-	return this
+func (fc *FilledCurve) AppendCurve(curve draw.CubicBezierCurve) *FilledCurve {
+	fc.curves = append(fc.curves, curve)
+	return fc
 }
 
 // SetFillColor sets the fill color for the path.
-func (this *FilledCurve) SetFillColor(color Color) {
-	this.fillColor = pdf.NewPdfColorDeviceRGB(color.ToRGB())
+func (fc *FilledCurve) SetFillColor(color Color) {
+	fc.fillColor = pdf.NewPdfColorDeviceRGB(color.ToRGB())
 }
 
 // SetBorderColor sets the border color for the path.
-func (this *FilledCurve) SetBorderColor(color Color) {
-	this.borderColor = pdf.NewPdfColorDeviceRGB(color.ToRGB())
+func (fc *FilledCurve) SetBorderColor(color Color) {
+	fc.borderColor = pdf.NewPdfColorDeviceRGB(color.ToRGB())
 }
 
 // draw draws the filled curve. Can specify a graphics state (gsName) for setting opacity etc. Otherwise leave empty ("").
 // Returns the content stream as a byte array, the bounding box and an error on failure.
-func (this *FilledCurve) draw(gsName string) ([]byte, *pdf.PdfRectangle, error) {
+func (fc *FilledCurve) draw(gsName string) ([]byte, *pdf.PdfRectangle, error) {
 	bpath := draw.NewCubicBezierPath()
-	for _, c := range this.curves {
+	for _, c := range fc.curves {
 		bpath = bpath.AppendCurve(c)
 	}
 
 	creator := pdfcontent.NewContentCreator()
 	creator.Add_q()
 
-	if this.FillEnabled {
-		creator.Add_rg(this.fillColor.R(), this.fillColor.G(), this.fillColor.B())
+	if fc.FillEnabled {
+		creator.Add_rg(fc.fillColor.R(), fc.fillColor.G(), fc.fillColor.B())
 	}
-	if this.BorderEnabled {
-		creator.Add_RG(this.borderColor.R(), this.borderColor.G(), this.borderColor.B())
-		creator.Add_w(this.BorderWidth)
+	if fc.BorderEnabled {
+		creator.Add_RG(fc.borderColor.R(), fc.borderColor.G(), fc.borderColor.B())
+		creator.Add_w(fc.BorderWidth)
 	}
 	if len(gsName) > 1 {
 		// If a graphics state is provided, use it. (can support transparency).
@@ -71,23 +71,23 @@ func (this *FilledCurve) draw(gsName string) ([]byte, *pdf.PdfRectangle, error) 
 	draw.DrawBezierPathWithCreator(bpath, creator)
 	creator.Add_h() // Close the path.
 
-	if this.FillEnabled && this.BorderEnabled {
+	if fc.FillEnabled && fc.BorderEnabled {
 		creator.Add_B() // fill and stroke.
-	} else if this.FillEnabled {
+	} else if fc.FillEnabled {
 		creator.Add_f() // Fill.
-	} else if this.BorderEnabled {
+	} else if fc.BorderEnabled {
 		creator.Add_S() // Stroke.
 	}
 	creator.Add_Q()
 
 	// Get bounding box.
 	pathBbox := bpath.GetBoundingBox()
-	if this.BorderEnabled {
+	if fc.BorderEnabled {
 		// Account for stroke width.
-		pathBbox.Height += this.BorderWidth
-		pathBbox.Width += this.BorderWidth
-		pathBbox.X -= this.BorderWidth / 2
-		pathBbox.Y -= this.BorderWidth / 2
+		pathBbox.Height += fc.BorderWidth
+		pathBbox.Width += fc.BorderWidth
+		pathBbox.X -= fc.BorderWidth / 2
+		pathBbox.Y -= fc.BorderWidth / 2
 	}
 
 	// Bounding box - global coordinate system.
@@ -100,10 +100,10 @@ func (this *FilledCurve) draw(gsName string) ([]byte, *pdf.PdfRectangle, error) 
 }
 
 // GeneratePageBlocks draws the filled curve on page blocks.
-func (this *FilledCurve) GeneratePageBlocks(ctx DrawContext) ([]*Block, DrawContext, error) {
+func (fc *FilledCurve) GeneratePageBlocks(ctx DrawContext) ([]*Block, DrawContext, error) {
 	block := NewBlock(ctx.PageWidth, ctx.PageHeight)
 
-	contents, _, err := this.draw("")
+	contents, _, err := fc.draw("")
 	err = block.addContentsByString(string(contents))
 	if err != nil {
 		return nil, ctx, err

--- a/pdf/creator/image.go
+++ b/pdf/creator/image.go
@@ -332,8 +332,7 @@ func drawImageOnBlock(blk *Block, img *Image, ctx DrawContext) (DrawContext, err
 		ctx.Y += img.Height()
 		ctx.Height -= img.Height()
 		return ctx, nil
-	} else {
-		// Absolute positioning - return original context.
-		return origCtx, nil
 	}
+	// Absolute positioning - return original context.
+	return origCtx, nil
 }

--- a/pdf/creator/paragraph.go
+++ b/pdf/creator/paragraph.go
@@ -209,7 +209,7 @@ func (p *Paragraph) Height() float64 {
 	return h
 }
 
-// Calculate the text width (if not wrapped).
+// getTextWidth calculates the text width as if all in one line (not taking wrapping into account).
 func (p *Paragraph) getTextWidth() float64 {
 	w := float64(0.0)
 

--- a/pdf/creator/paragraph.go
+++ b/pdf/creator/paragraph.go
@@ -193,9 +193,8 @@ func (p *Paragraph) SetWidth(width float64) {
 func (p *Paragraph) Width() float64 {
 	if p.enableWrap {
 		return p.wrapWidth
-	} else {
-		return p.getTextWidth() / 1000.0
 	}
+	return p.getTextWidth() / 1000.0
 }
 
 // Height returns the height of the Paragraph. The height is calculated based on the input text and how it is wrapped
@@ -382,10 +381,9 @@ func (p *Paragraph) GeneratePageBlocks(ctx DrawContext) ([]*Block, DrawContext, 
 		ctx.X -= p.margins.left // Move back.
 		ctx.Width = origContext.Width
 		return blocks, ctx, nil
-	} else {
-		// Absolute: not changing the context.
-		return blocks, origContext, nil
 	}
+	// Absolute: not changing the context.
+	return blocks, origContext, nil
 }
 
 // Draw block on specified location on Page, adding to the content stream.

--- a/pdf/creator/table.go
+++ b/pdf/creator/table.go
@@ -390,14 +390,14 @@ func (table *Table) GeneratePageBlocks(ctx DrawContext) ([]*Block, DrawContext, 
 
 	if table.positioning.isAbsolute() {
 		return blocks, origCtx, nil
-	} else {
-		// Move back X after.
-		ctx.X = origCtx.X
-		// Return original width
-		ctx.Width = origCtx.Width
-		// Add the bottom margin
-		ctx.Y += table.margins.bottom
 	}
+	// Relative mode.
+	// Move back X after.
+	ctx.X = origCtx.X
+	// Return original width
+	ctx.Width = origCtx.Width
+	// Add the bottom margin
+	ctx.Y += table.margins.bottom
 
 	return blocks, ctx, nil
 }

--- a/pdf/creator/table_test.go
+++ b/pdf/creator/table_test.go
@@ -1,0 +1,230 @@
+/*
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.md', which is part of this source code package.
+ */
+
+package creator
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/unidoc/unidoc/pdf/model/fonts"
+)
+
+func TestTableMultiParagraphWrapped(t *testing.T) {
+	c := New()
+
+	pageHistoryTable := NewTable(4)
+	pageHistoryTable.SetColumnWidths(0.1, 0.6, 0.15, 0.15)
+	content := [][]string{
+		{"1", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"1", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"1", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"1", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"1", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+	}
+	fontHelvetica := fonts.NewFontHelvetica()
+	for _, rows := range content {
+		for _, txt := range rows {
+			p := NewParagraph(txt)
+			p.SetFontSize(12)
+			p.SetFont(fontHelvetica)
+			p.SetColor(ColorBlack)
+			p.SetEnableWrap(true)
+
+			cell := pageHistoryTable.NewCell()
+			cell.SetBorder(CellBorderStyleBox, 1)
+			cell.SetContent(p)
+		}
+	}
+
+	err := c.Draw(pageHistoryTable)
+	if err != nil {
+		t.Fatalf("Error drawing: %v", err)
+	}
+
+	err = c.WriteToFile("/tmp/table_pagehist.pdf")
+	if err != nil {
+		t.Fatalf("Fail: %v\n", err)
+	}
+}
+
+func TestTableWithImage(t *testing.T) {
+	c := New()
+
+	pageHistoryTable := NewTable(4)
+	pageHistoryTable.SetColumnWidths(0.1, 0.6, 0.15, 0.15)
+	content := [][]string{
+		{"1", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"1", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"1", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"1", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"1", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+	}
+	fontHelvetica := fonts.NewFontHelvetica()
+	for _, rows := range content {
+		for _, txt := range rows {
+			p := NewParagraph(txt)
+			p.SetFontSize(12)
+			p.SetFont(fontHelvetica)
+			p.SetColor(ColorBlack)
+			p.SetEnableWrap(true)
+
+			cell := pageHistoryTable.NewCell()
+			cell.SetBorder(CellBorderStyleBox, 1)
+			err := cell.SetContent(p)
+			if err != nil {
+				t.Fatalf("Error: %v", err)
+			}
+		}
+	}
+
+	pageHistoryTable.SkipCells(1)
+
+	// Add image
+	imgData, err := ioutil.ReadFile(testImageFile1)
+	if err != nil {
+		t.Errorf("Fail: %v\n", err)
+		return
+	}
+	img, err := NewImageFromData(imgData)
+	if err != nil {
+		t.Errorf("Fail: %v\n", err)
+		return
+	}
+
+	img.margins.top = 2.0
+	img.margins.bottom = 2.0
+	img.margins.left = 2.0
+	img.margins.bottom = 2.0
+	img.ScaleToWidth(0.3 * c.Width())
+	fmt.Printf("Scaling image to width: %v\n", 0.5*c.Width())
+
+	cell := pageHistoryTable.NewCell()
+	cell.SetContent(img)
+	cell.SetBorder(CellBorderStyleBox, 1)
+
+	err = c.Draw(pageHistoryTable)
+	if err != nil {
+		t.Fatalf("Error drawing: %v", err)
+	}
+
+	err = c.WriteToFile("/tmp/table_pagehist_with_img.pdf")
+	if err != nil {
+		t.Fatalf("Fail: %v\n", err)
+	}
+}
+
+func TestTableWithDiv(t *testing.T) {
+	c := New()
+
+	pageHistoryTable := NewTable(4)
+	pageHistoryTable.SetColumnWidths(0.1, 0.6, 0.15, 0.15)
+
+	headings := []string{
+		"", "Description", "Passing", "Total",
+	}
+	content := [][]string{
+		{"1", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"2", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"3", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"3", "FullText Search Highlight the Term in Results. Going hunting in the winter can be fruitful, especially if it has not been too cold and the deer are well fed. \n\nissues 60", "120 90 30", "130 1"},
+		{"4", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"5", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"6", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130 a b c d e f g"},
+		{"7", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"8", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130 gogogoggogoogogo"},
+		{"9", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"10", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"11", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"12", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"13", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"14", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"15", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"16", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"17", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"18", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"19", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+		{"20", "FullText Search Highlight the Term in Results \n\nissues 60", "120", "130"},
+	}
+	fontHelvetica := fonts.NewFontHelvetica()
+	fontHelveticaBold := fonts.NewFontHelveticaBold()
+	for _, rows := range content {
+		for colIdx, txt := range rows {
+			p := NewParagraph(txt)
+			p.SetFontSize(12)
+			p.SetFont(fontHelvetica)
+			p.SetColor(ColorBlack)
+			p.SetMargins(0, 5, 10.0, 10.0)
+			if len(txt) > 10 {
+				p.SetTextAlignment(TextAlignmentJustify)
+			} else {
+				p.SetTextAlignment(TextAlignmentCenter)
+			}
+
+			// Place cell contents (header and text) inside a div.
+			div := NewDivision()
+
+			if len(headings[colIdx]) > 0 {
+				heading := NewParagraph(headings[colIdx])
+				heading.SetFontSize(14)
+				heading.SetFont(fontHelveticaBold)
+				heading.SetColor(ColorRed)
+				heading.SetTextAlignment(TextAlignmentCenter)
+				err := div.Add(heading)
+				if err != nil {
+					t.Fatalf("Error: %v", err)
+				}
+			}
+
+			err := div.Add(p)
+			if err != nil {
+				t.Fatalf("Error: %v", err)
+			}
+
+			cell := pageHistoryTable.NewCell()
+			cell.SetBorder(CellBorderStyleBox, 1)
+			err = cell.SetContent(div)
+			if err != nil {
+				t.Fatalf("Error: %v", err)
+			}
+		}
+	}
+
+	pageHistoryTable.SkipCells(1)
+
+	// Add image
+	imgData, err := ioutil.ReadFile(testImageFile1)
+	if err != nil {
+		t.Errorf("Fail: %v\n", err)
+		return
+	}
+	img, err := NewImageFromData(imgData)
+	if err != nil {
+		t.Errorf("Fail: %v\n", err)
+		return
+	}
+
+	img.margins.top = 2.0
+	img.margins.bottom = 2.0
+	img.margins.left = 2.0
+	img.margins.bottom = 2.0
+	img.ScaleToWidth(0.2 * c.Width())
+	fmt.Printf("Scaling image to width: %v\n", 0.5*c.Width())
+
+	cell := pageHistoryTable.NewCell()
+	cell.SetContent(img)
+	cell.SetBorder(CellBorderStyleBox, 1)
+
+	err = c.Draw(pageHistoryTable)
+	if err != nil {
+		t.Fatalf("Error drawing: %v", err)
+	}
+
+	err = c.WriteToFile("/tmp/table_pagehist_with_div.pdf")
+	if err != nil {
+		t.Fatalf("Fail: %v\n", err)
+	}
+}


### PR DESCRIPTION
New Division container component for containing multiple Drawables and can wrap across pages (unlike Block). Can be used in table cells to contain multiple paragraphs with different styles.

Support added for Division and Image in table cell.