### PR TITLE
Change PdfWriter dependency from io.WriteSeeker to io.Writer - enabli…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,10 +63,9 @@ node {
         stage('Build examples') {
             // Pull unidoc-examples from connected branch, or master otherwise.
             def examplesBranch = "master"
-            switch("${env.BRANCH_NAME}") {
-                case "v3":
-                    examplesBranch = "v3"
-                    break
+
+            if (env.BRANCH_NAME.take(3) == "v3-") {
+                examplesBranch = "v3"
             }
             echo "Pulling unidoc-examples on branch ${examplesBranch}"
             git url: 'https://github.com/unidoc/unidoc-examples.git', branch: examplesBranch


### PR DESCRIPTION
Changes PdfWriter dependency from io.WriteSeeker to io.Writer.  Instead of using Seek to find position, tracks output write position by tracking all written out bytes and uses to construct cross reference table.
Makes it easy to write output PDF to memory instead of file.