### PR TITLE
Adding customerName parameter to SetLicenseKey

### DIFF
--- a/common/license/util.go
+++ b/common/license/util.go
@@ -6,14 +6,23 @@
 // Package license helps manage commercial licenses and check if they are valid for the version of unidoc used.
 package license
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Defaults to the open source license.
 var licenseKey *LicenseKey = MakeUnlicensedKey()
 
 // Sets and validates the license key.
-func SetLicenseKey(content string) error {
+func SetLicenseKey(content string, customerName string) error {
 	lk, err := licenseKeyDecode(content)
 	if err != nil {
 		return err
+	}
+
+	if strings.ToLower(lk.CustomerName) != strings.ToLower(customerName) {
+		return fmt.Errorf("Customer name mismatch, expected '%s', but got '%s'", customerName, lk.CustomerName)
 	}
 
 	err = lk.Validate()


### PR DESCRIPTION
This is to make the license information more verbose. Breaking change.