### PR TITLE
Render.v3.hungarian

### DIFF
--- a/pdf/creator/chapters.go
+++ b/pdf/creator/chapters.go
@@ -57,7 +57,7 @@ func (c *Creator) NewChapter(title string) *Chapter {
 	heading := fmt.Sprintf("%d. %s", c.chapters, title)
 	p := NewParagraph(heading)
 	p.SetFontSize(16)
-	helvetica, _ := model.NewStandard14Font("Helvetica")
+	helvetica := model.NewStandard14FontMustCompile(model.Helvetica)
 	p.SetFont(helvetica) // bold?
 
 	chap.heading = p

--- a/pdf/creator/creator_test.go
+++ b/pdf/creator/creator_test.go
@@ -37,6 +37,10 @@ const testImageFile2 = "./testdata/signature.png"
 const testRobotoRegularTTFFile = "./testdata/roboto/Roboto-Regular.ttf"
 const testRobotoBoldTTFFile = "./testdata/roboto/Roboto-Bold.ttf"
 const testWts11TTFFile = "./testdata/wts11.ttf"
+
+// XXX: /tmp/2_p_multi.pdf which is created in this test gives an error message when opened in
+//      Adobe Reader: The font FreeSans contains bad Widths.
+//      This problem did not occur when I replaced FreeSans.ttf with LiberationSans-Regular.ttf
 const testFreeSansTTFFile = "./testdata/FreeSans.ttf"
 
 func TestTemplate1(t *testing.T) {

--- a/pdf/creator/creator_test.go
+++ b/pdf/creator/creator_test.go
@@ -501,11 +501,7 @@ func TestParagraphFonts(t *testing.T) {
 		return
 	}
 
-	helvetica, err := model.NewStandard14Font("Helvetica")
-	if err != nil {
-		t.Errorf("Fail: %v", err)
-		return
-	}
+	helvetica := model.NewStandard14FontMustCompile(model.Helvetica)
 
 	fonts := []*model.PdfFont{roboto, robotoBold, helvetica, roboto, robotoBold, helvetica}
 	for _, font := range fonts {
@@ -539,21 +535,21 @@ func TestParagraphFonts(t *testing.T) {
 func TestParagraphStandardFonts(t *testing.T) {
 	creator := New()
 
-	names := []string{
-		"Courier",
-		"Courier-Bold",
-		"Courier-BoldOblique",
-		"Courier-Oblique",
-		"Helvetica",
-		"Helvetica-Bold",
-		"Helvetica-BoldOblique",
-		"Helvetica-Oblique",
-		"Times-Roman",
-		"Times-Bold",
-		"Times-BoldItalic",
-		"Times-Italic",
-		"Symbol",
-		"ZapfDingbats",
+	names := []model.Standard14Font{
+		model.Courier,
+		model.CourierBold,
+		model.CourierBoldOblique,
+		model.CourierOblique,
+		model.Helvetica,
+		model.HelveticaBold,
+		model.HelveticaBoldOblique,
+		model.HelveticaOblique,
+		model.TimesRoman,
+		model.TimesBold,
+		model.TimesBoldItalic,
+		model.TimesItalic,
+		model.Symbol,
+		model.ZapfDingbats,
 	}
 
 	texts := []string{
@@ -577,11 +573,7 @@ func TestParagraphStandardFonts(t *testing.T) {
 
 	for idx, name := range names {
 		p := NewParagraph(texts[idx])
-		font, err := model.NewStandard14Font(name)
-		if err != nil {
-			t.Errorf("Fail: %v", err)
-			return
-		}
+		font := model.NewStandard14FontMustCompile(name)
 		p.SetFont(font)
 		p.SetFontSize(12)
 		p.SetLineHeight(1.2)
@@ -595,7 +587,7 @@ func TestParagraphStandardFonts(t *testing.T) {
 			p.SetEncoder(textencoding.NewZapfDingbatsEncoder())
 		}
 
-		err = creator.Draw(p)
+		err := creator.Draw(p)
 		if err != nil {
 			t.Errorf("Fail: %v\n", err)
 			return
@@ -1243,7 +1235,7 @@ func newContent(text string, alignment TextAlignment, font *model.PdfFont, fontS
 }
 
 func newBillItem(t *Table, no, date, notes, amount, con, retApplied, ret, netBill string) {
-	timesBold, _ := model.NewStandard14Font("Times-Bold")
+	timesBold := model.NewStandard14FontMustCompile(model.TimesBold)
 
 	billNo := t.NewCell()
 	billNo.SetContent(newContent(no, TextAlignmentLeft, timesBold, 8, ColorBlack))
@@ -1265,8 +1257,8 @@ func newBillItem(t *Table, no, date, notes, amount, con, retApplied, ret, netBil
 
 // Test creating and drawing a table.
 func TestCreatorHendricksReq1(t *testing.T) {
-	timesRoman, _ := model.NewStandard14Font("Times-Roman")
-	timesBold, _ := model.NewStandard14Font("Times-Bold")
+	timesRoman := model.NewStandard14FontMustCompile(model.TimesRoman)
+	timesBold := model.NewStandard14FontMustCompile(model.TimesBold)
 	table := NewTable(3) // Mx4 table
 	// Default, equal column sizes (4x0.25)...
 	table.SetColumnWidths(0.35, 0.30, 0.35)
@@ -1464,7 +1456,7 @@ func TestCreatorHendricksReq1(t *testing.T) {
 }
 
 func TestCreatorTableBorderReq1(t *testing.T) {
-	timesRoman, _ := model.NewStandard14Font("Times-Roman")
+	timesRoman := model.NewStandard14FontMustCompile(model.TimesRoman)
 	table := NewTable(1) // Mx4 table
 	table.SetColumnWidths(1)
 
@@ -1794,7 +1786,7 @@ func TestCreatorTableBorderReq1(t *testing.T) {
 }
 
 func TestCellBorder(t *testing.T) {
-	timesBold, _ := model.NewStandard14Font("Times-Bold")
+	timesBold := model.NewStandard14FontMustCompile(model.TimesBold)
 
 	table := NewTable(2)
 	table.SetColumnWidths(0.50, 0.50)
@@ -1816,16 +1808,8 @@ func TestCellBorder(t *testing.T) {
 func TestTableInSubchapter(t *testing.T) {
 	c := New()
 
-	fontRegular, err := model.NewStandard14Font("Helvetica")
-	if err != nil {
-		t.Errorf("Fail: %v", err)
-		return
-	}
-	fontBold, err := model.NewStandard14Font("Helvetica-Bold")
-	if err != nil {
-		t.Errorf("Fail: %v", err)
-		return
-	}
+	fontRegular := model.NewStandard14FontMustCompile(model.Helvetica)
+	fontBold := model.NewStandard14FontMustCompile(model.HelveticaBold)
 
 	ch := c.NewChapter("Document control")
 	ch.SetMargins(0, 0, 40, 0)
@@ -1907,7 +1891,7 @@ func TestTableInSubchapter(t *testing.T) {
 	myPara.SetLineHeight(1.5)
 	sc.Add(myPara)
 
-	err = c.Draw(ch)
+	err := c.Draw(ch)
 	if err != nil {
 		t.Errorf("Fail: %v\n", err)
 		return

--- a/pdf/creator/subchapter.go
+++ b/pdf/creator/subchapter.go
@@ -56,7 +56,7 @@ func (c *Creator) NewSubchapter(ch *Chapter, title string) *Subchapter {
 	p := NewParagraph(heading)
 
 	p.SetFontSize(14)
-	helvetica, _ := model.NewStandard14Font("Helvetica")
+	helvetica := model.NewStandard14FontMustCompile(model.Helvetica)
 	p.SetFont(helvetica) // bold?
 
 	subchap.showNumbering = true

--- a/pdf/extractor/text.go
+++ b/pdf/extractor/text.go
@@ -626,7 +626,7 @@ func (to *textObject) getFont(name string) (*model.PdfFont, error) {
 
 	// This is a hack for testing.
 	if name == "UniDocCourier" {
-		return model.NewStandard14Font("Courier")
+		return model.NewStandard14FontMustCompile(model.Courier), nil
 	}
 
 	fontObj, err := to.getFontDict(name)

--- a/pdf/internal/cmap/cmap.go
+++ b/pdf/internal/cmap/cmap.go
@@ -47,15 +47,30 @@ type CMap struct {
 	nbits      int // 8 bits for simple fonts, 16 bits for CID fonts.
 	ctype      int
 	version    string
-	usecmap    string // Base this cmap on `usecmap` if `usecmap` is not empty
+	usecmap    string // Base this cmap on `usecmap` if `usecmap` is not empty.
 	systemInfo CIDSystemInfo
 
-	// For regular cmaps
+	// For regular cmaps.
 	codespaces []Codespace
 
-	// For ToUnicode (ctype 2) cmaps
-	codeToUnicode     map[CharCode]string
-	toUnicodeIdentity bool
+	// For ToUnicode (ctype 2) cmaps.
+	codeToUnicode map[CharCode]string
+}
+
+// NewToUnicodeCMap returns an identity CMap with codeToUnicode matching the `codeToUnicode` arg.
+func NewToUnicodeCMap(codeToUnicode map[CharCode]string) *CMap {
+	return &CMap{
+		name:  "Adobe-Identity-UCS",
+		ctype: 2,
+		nbits: 16,
+		systemInfo: CIDSystemInfo{
+			Registry:   "Adobe",
+			Ordering:   "UCS",
+			Supplement: 0,
+		},
+		codespaces:    []Codespace{Codespace{Low: 0, High: 0xffff}},
+		codeToUnicode: codeToUnicode,
+	}
 }
 
 // String returns a human readable description of `cmap`.
@@ -100,7 +115,7 @@ func (info *CIDSystemInfo) String() string {
 	return fmt.Sprintf("%s-%s-%03d", info.Registry, info.Ordering, info.Supplement)
 }
 
-// NewCIDSystemInfo returns the CIDSystemInfo encoded in PDFObject `obj`
+// NewCIDSystemInfo returns the CIDSystemInfo encoded in PDFObject `obj`.
 func NewCIDSystemInfo(obj core.PdfObject) (info CIDSystemInfo, err error) {
 	d, ok := core.GetDict(obj)
 	if !ok {
@@ -135,7 +150,7 @@ func (cmap *CMap) Type() int {
 	return cmap.ctype
 }
 
-// MissingCodeRune replaces runes that can't be decoded. '\ufffd' = �. Was '?'
+// MissingCodeRune replaces runes that can't be decoded. '\ufffd' = �. Was '?'.
 const MissingCodeRune = textencoding.MissingCodeRune
 
 // MissingCodeString replaces strings that can't be decoded.
@@ -182,8 +197,8 @@ func (cmap *CMap) CharcodeToUnicode(code CharCode) (string, bool) {
 	if s, ok := cmap.codeToUnicode[code]; ok {
 		return s, true
 	}
-	common.Log.Debug("ERROR: CharcodeToUnicode could not convert code=0x%04x. cmap=%s. Returning %q",
-		code, cmap, MissingCodeString)
+	// common.Log.Debug("ERROR: CharcodeToUnicode could not convert code=0x%04x. cmap=%s. Returning %q",
+	// 	code, cmap, MissingCodeString)
 	return MissingCodeString, false
 }
 
@@ -213,7 +228,7 @@ func (cmap *CMap) bytesToCharcodes(data []byte) ([]CharCode, bool) {
 	return charcodes, true
 }
 
-// matchCode attempts to match the byte array `data` with a character code in `cmap`'s codespaces
+// matchCode attempts to match the byte array `data` with a character code in `cmap`'s codespaces.
 // Returns:
 //      character code (if there is a match) of
 //      number of bytes read (if there is a match)
@@ -252,7 +267,7 @@ func LoadCmapFromDataCID(data []byte) (*CMap, error) {
 }
 
 // LoadCmapFromData parses the in-memory cmap `data` and returns the resulting CMap.
-// If isCID is true then it uses 1-byte encodings, otherwise it uses the codespaces in the cmap.
+// If `isSimple` is true, it uses 1-byte encodings, otherwise it uses the codespaces in the cmap.
 //
 // 9.10.3 ToUnicode CMaps (page 293)
 func LoadCmapFromData(data []byte, isSimple bool) (*CMap, error) {
@@ -274,9 +289,132 @@ func LoadCmapFromData(data []byte, isSimple bool) (*CMap, error) {
 		common.Log.Debug("ERROR: No codespaces. cmap=%s", cmap)
 		return nil, ErrBadCMap
 	}
-	// We need to sort codespaces so that we check shorter codes first
+	// We need to sort codespaces so that we check shorter codes first.
 	sort.Slice(cmap.codespaces, func(i, j int) bool {
 		return cmap.codespaces[i].Low < cmap.codespaces[j].Low
 	})
 	return cmap, nil
+}
+
+// Bytes returns the raw bytes of a PDF CMap corresponding to `cmap`.
+func (cmap *CMap) Bytes() []byte {
+	common.Log.Trace("cmap.Bytes: cmap=%s", cmap.String())
+	body := cmap.toBfData()
+	whole := strings.Join([]string{cmapHeader, body, cmapTrailer}, "\n")
+	return []byte(whole)
+}
+
+type (
+	charRange struct {
+		code0 CharCode
+		code1 CharCode
+	}
+	fbRange struct {
+		code0 CharCode
+		code1 CharCode
+		r0    rune
+	}
+)
+
+// toBfData returns the bfchar and bfrange sections of a CMap text file.
+// Both sections are computed from cmap.codeToUnicode.
+func (cmap *CMap) toBfData() string {
+	if len(cmap.codeToUnicode) == 0 {
+		return ""
+	}
+
+	// codes is a sorted list of the codeToUnicode keys.
+	codes := []CharCode{}
+	for code := range cmap.codeToUnicode {
+		codes = append(codes, code)
+	}
+	sort.Slice(codes, func(i, j int) bool { return codes[i] < codes[j] })
+
+	// charRanges is a list of the contiguous character code ranges in codes.
+	charRanges := []charRange{}
+	c0, c1 := codes[0], codes[0]+1
+	for _, c := range codes[1:] {
+		if c != c1 {
+			charRanges = append(charRanges, charRange{c0, c1})
+			c0 = c
+		}
+		c1 = c + 1
+	}
+	if c1 != c0+1 {
+		charRanges = append(charRanges, charRange{c0, c1})
+	}
+
+	// fbChars is a list of single character ranges. fbRanges is a list of multiple character ranges.
+	fbChars := []CharCode{}
+	fbRanges := []fbRange{}
+	for _, cr := range charRanges {
+		if cr.code0+1 == cr.code1 {
+			fbChars = append(fbChars, cr.code0)
+		} else {
+			fbRanges = append(fbRanges, fbRange{
+				code0: cr.code0,
+				code1: cr.code1,
+				r0:    []rune(cmap.codeToUnicode[cr.code0])[0],
+			})
+		}
+	}
+	common.Log.Trace("charRanges=%d fbChars=%d fbRanges=%d", len(charRanges), len(fbChars),
+		len(fbRanges))
+
+	lines := []string{}
+	if len(fbChars) > 0 {
+		numRanges := (len(fbChars) + maxBfEntries - 1) / maxBfEntries
+		for i := 0; i < numRanges; i++ {
+			n := min(len(fbChars)-i*maxBfEntries, maxBfEntries)
+			lines = append(lines, fmt.Sprintf("%d beginbfchar", n))
+			for j := 0; j < n; j++ {
+				code := fbChars[i*maxBfEntries+j]
+				s := cmap.codeToUnicode[code]
+				r := []rune(s)[0]
+				lines = append(lines, fmt.Sprintf("<%04x> <%04x>", code, r))
+			}
+			lines = append(lines, "endbfchar")
+		}
+	}
+	if len(fbRanges) > 0 {
+		numRanges := (len(fbRanges) + maxBfEntries - 1) / maxBfEntries
+		for i := 0; i < numRanges; i++ {
+			n := min(len(fbRanges)-i*maxBfEntries, maxBfEntries)
+			lines = append(lines, fmt.Sprintf("%d beginbfrange", n))
+			for j := 0; j < n; j++ {
+				rng := fbRanges[i*maxBfEntries+j]
+				r := rng.r0
+				lines = append(lines, fmt.Sprintf("<%04x><%04x> <%04x>", rng.code0, rng.code1-1, r))
+			}
+			lines = append(lines, "endbfrange")
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+const (
+	maxBfEntries = 100 // Maximum number of entries in a bfchar or bfrange section.
+	cmapHeader   = `
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+`
+	cmapTrailer = `endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+`
+)
+
+func min(i, j int) int {
+	if i < j {
+		return i
+	}
+	return j
 }

--- a/pdf/internal/cmap/cmap_parser.go
+++ b/pdf/internal/cmap/cmap_parser.go
@@ -416,7 +416,7 @@ func (cmap *CMap) parseBfchar() error {
 	return nil
 }
 
-// parseBfrange parses a c section of a CMap file.
+// parseBfrange parses a bfrange section of a CMap file.
 func (cmap *CMap) parseBfrange() error {
 	for {
 		// The specifications are in triplets.

--- a/pdf/model/font.go
+++ b/pdf/model/font.go
@@ -448,12 +448,12 @@ type fontCommon struct {
 	basefont string // The font's "BaseFont" field.
 	subtype  string // The font's "Subtype" field.
 
-	// These are optional fields in the PDF font
+	// These are optional fields in the PDF font.
 	toUnicode core.PdfObject // The stream containing toUnicodeCmap. We keep it around for ToPdfObject.
 
 	// These objects are computed from optional fields in the PDF font.
-	toUnicodeCmap  *cmap.CMap         // Computed from "ToUnicode"
-	fontDescriptor *PdfFontDescriptor // Computed from "FontDescriptor"
+	toUnicodeCmap  *cmap.CMap         // Computed from "ToUnicode".
+	fontDescriptor *PdfFontDescriptor // Computed from "FontDescriptor".
 
 	// objectNumber helps us find the font in the PDF being processed. This helps with debugging.
 	objectNumber int64
@@ -482,6 +482,14 @@ func (base fontCommon) asPdfObjectDictionary(subtype string) *core.PdfObjectDict
 	}
 	if base.toUnicode != nil {
 		d.Set("ToUnicode", base.toUnicode)
+	} else if base.toUnicodeCmap != nil {
+		data := base.toUnicodeCmap.Bytes()
+		o, err := core.MakeStream(data, nil)
+		if err != nil {
+			common.Log.Debug("MakeStream failed. err=%v", err)
+		} else {
+			d.Set("ToUnicode", o)
+		}
 	}
 	return d
 }
@@ -584,7 +592,7 @@ func newFontBaseFieldsFromPdfObject(fontObj core.PdfObject) (*core.PdfObjectDict
 	return d, font, nil
 }
 
-// toUnicodeToCmap returns a CMap of `toUnicode` if it exists
+// toUnicodeToCmap returns a CMap of `toUnicode` if it exists.
 func toUnicodeToCmap(toUnicode core.PdfObject, font *fontCommon) (*cmap.CMap, error) {
 	toUnicodeStream, ok := toUnicode.(*core.PdfObjectStream)
 	if !ok {
@@ -673,7 +681,7 @@ func (descriptor *PdfFontDescriptor) String() string {
 	}
 	parts = append(parts, fmt.Sprintf("FontFile3=%t", descriptor.FontFile3 != nil))
 
-	return fmt.Sprintf("FONT_DESCRIPTON{%s}", strings.Join(parts, ", "))
+	return fmt.Sprintf("FONT_DESCRIPTOR{%s}", strings.Join(parts, ", "))
 }
 
 // newPdfFontDescriptorFromPdfObject loads the font descriptor from a core.PdfObject.  Can either be a

--- a/pdf/model/font.go
+++ b/pdf/model/font.go
@@ -71,13 +71,46 @@ func DefaultFont() *PdfFont {
 }
 
 // NewStandard14Font returns the standard 14 font named `basefont` as a *PdfFont, or an error if it
-// `basefont` is not one the standard 14 font names.
+// `basefont` is not one of the standard 14 font names.
 func NewStandard14Font(basefont string) (*PdfFont, error) {
 	std, ok := standard14Fonts[basefont]
 	if !ok {
+		common.Log.Debug("ERROR: Invalid standard 14 font name %#q", basefont)
 		return nil, ErrFontNotSupported
 	}
 	return &PdfFont{context: &std}, nil
+}
+
+// Standard14Font is to be used only to define the standard 14 font names that follow.
+// This guarantees that calls to NewStandard14FontMustCompile will succeed.
+type Standard14Font string
+
+const (
+	Courier              Standard14Font = "Courier"
+	CourierBold          Standard14Font = "Courier-Bold"
+	CourierBoldOblique   Standard14Font = "Courier-BoldOblique"
+	CourierOblique       Standard14Font = "Courier-Oblique"
+	Helvetica            Standard14Font = "Helvetica"
+	HelveticaBold        Standard14Font = "Helvetica-Bold"
+	HelveticaBoldOblique Standard14Font = "Helvetica-BoldOblique"
+	HelveticaOblique     Standard14Font = "Helvetica-Oblique"
+	TimesRoman           Standard14Font = "Times-Roman"
+	TimesBold            Standard14Font = "Times-Bold"
+	TimesBoldItalic      Standard14Font = "Times-BoldItalic"
+	TimesItalic          Standard14Font = "Times-Italic"
+	Symbol               Standard14Font = "Symbol"
+	ZapfDingbats         Standard14Font = "ZapfDingbats"
+)
+
+// NewStandard14FontMustCompile returns the standard 14 font named `basefont` as a *PdfFont.
+// If `basefont` is one of the 14 Standard14Font values defined above then NewStandard14FontMustCompile
+// is guaranteed to succeed.
+func NewStandard14FontMustCompile(basefont Standard14Font) *PdfFont {
+	font, err := NewStandard14Font(string(basefont))
+	if err != nil {
+		panic(fmt.Errorf("invalid Standard14Font %#q", basefont))
+	}
+	return font
 }
 
 // NewStandard14FontWithEncoding returns the standard 14 font named `basefont` as a *PdfFont and an

--- a/pdf/model/font_composite.go
+++ b/pdf/model/font_composite.go
@@ -197,7 +197,8 @@ type pdfCIDFontType0 struct {
 	encoder textencoding.TextEncoder
 
 	// Table 117 – Entries in a CIDFont dictionary (page 269)
-	CIDSystemInfo *core.PdfObjectDictionary // (Required) Dictionary that defines the character collection of the CIDFont. See Table 116.
+	CIDSystemInfo *core.PdfObjectDictionary // (Required) Dictionary that defines the character
+	// collection of the CIDFont. See Table 116.
 }
 
 // pdfCIDFontType0FromSkeleton returns a pdfCIDFontType0 with its common fields initalized.
@@ -527,6 +528,8 @@ func NewCompositePdfFontFromTTFFile(filePath string) (*PdfFont, error) {
 		Encoding: core.MakeName("Identity-H"),
 		encoder:  textencoding.NewTrueTypeFontEncoder(ttf.Chars),
 	}
+
+	type0.toUnicodeCmap = ttf.MakeToUnicode()
 
 	// Build Font.
 	font := PdfFont{

--- a/pdf/model/font_composite.go
+++ b/pdf/model/font_composite.go
@@ -472,6 +472,7 @@ func NewCompositePdfFontFromTTFFile(filePath string) (*PdfFont, error) {
 
 	// Make the font descriptor.
 	descriptor := &PdfFontDescriptor{}
+	descriptor.FontName = core.MakeName(ttf.PostScriptName)
 	descriptor.Ascent = core.MakeFloat(k * float64(ttf.TypoAscender))
 	descriptor.Descent = core.MakeFloat(k * float64(ttf.TypoDescender))
 	descriptor.CapHeight = core.MakeFloat(k * float64(ttf.CapHeight))

--- a/pdf/model/font_simple.go
+++ b/pdf/model/font_simple.go
@@ -377,6 +377,7 @@ func NewPdfFontFromTTFFile(filePath string) (*PdfFont, error) {
 	truefont.Encoding = core.MakeName("WinAnsiEncoding")
 
 	descriptor := &PdfFontDescriptor{}
+	descriptor.FontName = core.MakeName(ttf.PostScriptName)
 	descriptor.Ascent = core.MakeFloat(k * float64(ttf.TypoAscender))
 	descriptor.Descent = core.MakeFloat(k * float64(ttf.TypoDescender))
 	descriptor.CapHeight = core.MakeFloat(k * float64(ttf.CapHeight))

--- a/pdf/model/fonts/ttfparser.go
+++ b/pdf/model/fonts/ttfparser.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/unidoc/unidoc/common"
 	"github.com/unidoc/unidoc/pdf/core"
+	"github.com/unidoc/unidoc/pdf/internal/cmap"
 	"github.com/unidoc/unidoc/pdf/model/textencoding"
 )
 
@@ -83,13 +84,32 @@ type TtfType struct {
 	CapHeight              int16
 	Widths                 []uint16
 
-	// Chars maps rune values (unicode) to the indexes in GlyphNames. i.e GlyphNames[Chars[r]] is
+	// Chars maps rune values (unicode) to the indexes in GlyphNames. i.e. GlyphNames[Chars[r]] is
 	// the glyph corresponding to rune r.
 	Chars map[uint16]uint16
 	// GlyphNames is a list of glyphs from the "post" section of the TrueType file.
 	GlyphNames []string
 }
 
+// MakeToUnicode returns a ToUnicode CMap based on the encoding of `ttf`.
+// XX: This currently gives a bad text mapping for creator_test.go but leads to an otherwise
+// valid PDF file that Adobe Reader displays without error.
+func (ttf *TtfType) MakeToUnicode() *cmap.CMap {
+	codeToUnicode := map[cmap.CharCode]string{}
+	for code, idx := range ttf.Chars {
+		glyph := ttf.GlyphNames[idx]
+
+		r, ok := textencoding.GlyphToRune(glyph)
+		if !ok {
+			common.Log.Debug("No rune. code=0x%04x glyph=%q", code, glyph)
+			r = textencoding.MissingCodeRune
+		}
+		codeToUnicode[cmap.CharCode(code)] = string(r)
+	}
+	return cmap.NewToUnicodeCMap(codeToUnicode)
+}
+
+// String returns a human readable representation of `ttf`.
 func (ttf *TtfType) String() string {
 	return fmt.Sprintf("FONT_FILE2{%#q Embeddable=%t UnitsPerEm=%d Bold=%t ItalicAngle=%f "+
 		"CapHeight=%d Chars=%d GlyphNames=%d}",
@@ -420,6 +440,8 @@ func (t *ttfParser) ParseCmap() error {
 		if platformID == 3 && encodingID == 1 {
 			// (3,1) subtable. Windows Unicode.
 			offset31 = offset
+		} else if platformID == 1 && encodingID == 0 {
+			offset10 = offset
 		}
 	}
 
@@ -435,6 +457,9 @@ func (t *ttfParser) ParseCmap() error {
 		if err := t.parseCmapVersion(offset10); err != nil {
 			return err
 		}
+	}
+	if offset31 == 0 && offset10 == 0 {
+		common.Log.Debug("ttfParser.ParseCmap. No 31 or 10 table.")
 	}
 
 	return nil
@@ -516,11 +541,11 @@ func (t *ttfParser) parseCmapFormat12() error {
 		startGlyph := t.ReadULong()
 
 		if firstCode > 0x0010FFFF || (0xD800 <= firstCode && firstCode <= 0xDFFF) {
-			return errors.New("Invalid characters codes")
+			return errors.New("invalid characters codes")
 		}
 
 		if endCode < firstCode || endCode > 0x0010FFFF || (0xD800 <= endCode && endCode <= 0xDFFF) {
-			return errors.New("Invalid characters codes")
+			return errors.New("invalid characters codes")
 		}
 
 		for j := uint32(0); j <= endCode-firstCode; j++ {

--- a/pdf/model/textencoding/truetype.go
+++ b/pdf/model/textencoding/truetype.go
@@ -36,7 +36,7 @@ func NewTrueTypeFontEncoder(runeToGlyphIndexMap map[uint16]uint16) TrueTypeFontE
 }
 
 // ttEncoderNumEntries is the maximum number of encoding entries shown in SimpleEncoder.String()
-const ttEncoderNumEntries = 1000
+const ttEncoderNumEntries = 10
 
 // String returns a string that describes `enc`.
 func (enc TrueTypeFontEncoder) String() string {


### PR DESCRIPTION
I have fixed a few more things, mainly adding ToUnicode CMaps to CIDType2 fonts.

Nothing has regressed as far as I can tell, but I might have missed something.

The ToUnicode CMaps have incorrect character mappings, they all came out as identity mappings in my testing. I couldn't figure out why. You may be able to see  obvious mistakes in my code. 

There seems to be a problem with your FreeSans TrueType font. I tried other TrueType fonts in my own testing and the ToUnicode CMaps were still incorrect.

I noticed some TrueType tables not being extracted. I don't know if this is related to the ToUnicode CMap problems. 

I want to work on text extraction for the next few weeks then come back to creating correct ToUnicode CMaps