### PR TITLE
Implement AES encryption (128 and 256 bits)

### DIFF
--- a/pdf/core/crypt.go
+++ b/pdf/core/crypt.go
@@ -1628,5 +1628,16 @@ func (crypt *PdfCrypt) alg13(fkey []byte) (bool, error) {
 	if p != crypt.P {
 		return false, errors.New("permissions validation failed")
 	}
+	encMeta := true
+	if perms[8] == 'T' {
+		encMeta = true
+	} else if perms[8] == 'F' {
+		encMeta = false
+	} else {
+		return false, errors.New("decoded metadata encryption flag is invalid")
+	}
+	if encMeta != crypt.EncryptMetadata {
+		return false, errors.New("metadata encryption validation failed")
+	}
 	return true, nil
 }

--- a/pdf/core/crypt.go
+++ b/pdf/core/crypt.go
@@ -1117,6 +1117,14 @@ func (crypt *PdfCrypt) Encrypt(obj PdfObject, parentObjNum, parentGenNum int64) 
 	return nil
 }
 
+// aesZeroIV allocates a zero-filled buffer that serves as an initialization vector for AESv3.
+func (crypt *PdfCrypt) aesZeroIV() []byte {
+	if crypt.ivAESZero == nil {
+		crypt.ivAESZero = make([]byte, aes.BlockSize)
+	}
+	return crypt.ivAESZero
+}
+
 // alg2a retrieves the encryption key from an encrypted document (R >= 5).
 // It returns false if the password was wrong.
 // 7.6.4.3.2 Algorithm 2.A (page 83)
@@ -1184,10 +1192,8 @@ func (crypt *PdfCrypt) alg2a(pass []byte) (bool, error) {
 	if err != nil {
 		panic(err)
 	}
-	if crypt.ivAESZero == nil {
-		crypt.ivAESZero = make([]byte, aes.BlockSize)
-	}
-	iv := crypt.ivAESZero
+
+	iv := crypt.aesZeroIV()
 	cbc := cipher.NewCBCDecrypter(ac, iv)
 	fkey := make([]byte, 32)
 	cbc.CryptBlocks(fkey, ekey)

--- a/pdf/core/crypt.go
+++ b/pdf/core/crypt.go
@@ -1617,7 +1617,8 @@ func (crypt *PdfCrypt) alg12(opass []byte) ([]byte, error) {
 // alg13 validates user permissions (P+EncryptMetadata vs Perms) for R=6.
 // 7.6.4.4.11 Algorithm 13 (page 87)
 func (crypt *PdfCrypt) alg13(fkey []byte) (bool, error) {
-	perms := crypt.Perms[:16]
+	perms := make([]byte, 16)
+	copy(perms, crypt.Perms[:16])
 
 	ac, err := aes.NewCipher(fkey[:32])
 	if err != nil {

--- a/pdf/core/crypt_test.go
+++ b/pdf/core/crypt_test.go
@@ -284,7 +284,7 @@ func TestAESv3(t *testing.T) {
 					}
 
 					// generate encryption parameters
-					err := crypt.encryptR6([]byte(c.UserPass), []byte(c.OwnerPass))
+					err := crypt.generateR6([]byte(c.UserPass), []byte(c.OwnerPass))
 					if err != nil {
 						t.Fatal("Failed to encrypt:", err)
 					}

--- a/pdf/core/crypt_test.go
+++ b/pdf/core/crypt_test.go
@@ -149,7 +149,7 @@ func TestDecryption1(t *testing.T) {
 	crypter.DecryptedObjects = map[PdfObject]bool{}
 	// Default algorithm is V2 (RC4).
 	crypter.CryptFilters = CryptFilters{}
-	crypter.CryptFilters["Default"] = CryptFilter{Cfm: "V2", Length: crypter.Length}
+	crypter.CryptFilters[StandardCryptFilter] = CryptFilter{Cfm: "V2", Length: crypter.Length}
 	crypter.V = 2
 	crypter.R = 3
 	crypter.P = -3904

--- a/pdf/core/crypt_test.go
+++ b/pdf/core/crypt_test.go
@@ -8,8 +8,13 @@
 package core
 
 import (
+	"bytes"
+	"fmt"
+	"math"
 	"math/rand"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/unidoc/unidoc/common"
 )
@@ -228,5 +233,100 @@ func BenchmarkAlg2b(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = alg2b(data, pass, user)
+	}
+}
+
+func TestAESv3(t *testing.T) {
+	const keySize = 32
+
+	seed := time.Now().UnixNano()
+	rand := rand.New(rand.NewSource(seed))
+
+	var cases = []struct {
+		Name      string
+		EncMeta   bool
+		UserPass  string
+		OwnerPass string
+	}{
+		{
+			Name: "simple", EncMeta: true,
+			UserPass: "user", OwnerPass: "owner",
+		},
+		{
+			Name: "utf8", EncMeta: false,
+			UserPass: "æøå-u", OwnerPass: "æøå-o",
+		},
+		{
+			Name: "long", EncMeta: true,
+			UserPass:  strings.Repeat("user", 80),
+			OwnerPass: strings.Repeat("owner", 80),
+		},
+	}
+
+	const (
+		perms = 0x12345678
+	)
+
+	for _, R := range []int{5, 6} {
+		R := R
+		t.Run(fmt.Sprintf("R=%d", R), func(t *testing.T) {
+			for _, c := range cases {
+				c := c
+				t.Run(c.Name, func(t *testing.T) {
+					fkey := make([]byte, keySize)
+					rand.Read(fkey)
+
+					crypt := &PdfCrypt{
+						V: 5, R: R,
+						P:               perms,
+						EncryptionKey:   append([]byte{}, fkey...),
+						EncryptMetadata: c.EncMeta,
+					}
+
+					// generate encryption parameters
+					err := crypt.encryptR6([]byte(c.UserPass), []byte(c.OwnerPass))
+					if err != nil {
+						t.Fatal("Failed to encrypt:", err)
+					}
+
+					// Perms and EncryptMetadata are checked as a part of alg2a
+
+					// decrypt using user password
+					crypt.EncryptionKey = nil
+					ok, err := crypt.alg2a([]byte(c.UserPass))
+					if err != nil || !ok {
+						t.Error("Failed to authenticate user pass:", err)
+					} else if !bytes.Equal(crypt.EncryptionKey, fkey) {
+						t.Error("wrong encryption key")
+					}
+
+					// decrypt using owner password
+					crypt.EncryptionKey = nil
+					ok, err = crypt.alg2a([]byte(c.OwnerPass))
+					if err != nil || !ok {
+						t.Error("Failed to authenticate owner pass:", err)
+					} else if !bytes.Equal(crypt.EncryptionKey, fkey) {
+						t.Error("wrong encryption key")
+					}
+
+					// try to elevate user permissions
+					crypt.P = math.MaxUint32
+
+					crypt.EncryptionKey = nil
+					ok, err = crypt.alg2a([]byte(c.UserPass))
+					if R == 5 {
+						// it's actually possible with R=5, since Perms is not generated
+						if err != nil || !ok {
+							t.Error("Failed to authenticate user pass:", err)
+						}
+					} else {
+						// not possible in R=6, should return an error
+						if err == nil || ok {
+							t.Error("was able to elevate permissions with R=6")
+						}
+					}
+				})
+			}
+		})
 	}
 }

--- a/pdf/core/primitives.go
+++ b/pdf/core/primitives.go
@@ -127,6 +127,12 @@ func MakeArrayFromFloats(vals []float64) *PdfObjectArray {
 	return &array
 }
 
+// MakeBool creates an PdfObjectBool from a bool.
+func MakeBool(val bool) *PdfObjectBool {
+	v := PdfObjectBool(val)
+	return &v
+}
+
 // MakeFloat creates an PdfObjectFloat from a float64.
 func MakeFloat(val float64) *PdfObjectFloat {
 	num := PdfObjectFloat(val)

--- a/pdf/model/writer.go
+++ b/pdf/model/writer.go
@@ -15,14 +15,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/unidoc/unidoc/common"
 	"github.com/unidoc/unidoc/common/license"
 	. "github.com/unidoc/unidoc/pdf/core"
 	"github.com/unidoc/unidoc/pdf/model/fonts"
-	"strings"
 )
 
 var pdfCreator = ""
@@ -342,8 +343,6 @@ func (this *PdfWriter) AddPage(page *PdfPage) error {
 
 	this.addObject(pageObj)
 
-
-
 	// Traverse the page and record all object references.
 	err := this.addObjects(pDict)
 	if err != nil {
@@ -476,7 +475,20 @@ func (this *PdfWriter) updateObjectNumbers() {
 
 type EncryptOptions struct {
 	Permissions AccessPermissions
+	Algorithm   EncryptionAlgorithm
 }
+
+// EncryptionAlgorithm is used in EncryptOptions to change the default algorithm used to encrypt the document.
+type EncryptionAlgorithm int
+
+const (
+	// RC4_128bit uses RC4 encryption (128 bit)
+	RC4_128bit = EncryptionAlgorithm(iota)
+	// AES_128bit uses AES encryption (128 bit, PDF 1.6)
+	AES_128bit
+	// AES_256bit uses AES encryption (256 bit, PDF 2.0)
+	AES_256bit
+)
 
 // Encrypt the output file with a specified user/owner password.
 func (this *PdfWriter) Encrypt(userPass, ownerPass []byte, options *EncryptOptions) error {
@@ -486,17 +498,58 @@ func (this *PdfWriter) Encrypt(userPass, ownerPass []byte, options *EncryptOptio
 	crypter.EncryptedObjects = map[PdfObject]bool{}
 
 	crypter.CryptFilters = CryptFilters{}
-	crypter.CryptFilters["Default"] = CryptFilter{Cfm: "V2", Length: 128}
+
+	algo := RC4_128bit
+	if options != nil {
+		algo = options.Algorithm
+	}
+
+	var cf CryptFilter
+	switch algo {
+	case RC4_128bit:
+		crypter.V = 2
+		crypter.R = 3
+		crypter.Length = 128
+		cf = CryptFilter{Cfm: CryptFilterV2, Length: 16}
+	case AES_128bit:
+		this.SetVersion(1, 5)
+		crypter.V = 4
+		crypter.R = 4
+		crypter.Length = 128
+		cf = CryptFilter{Cfm: CryptFilterAESV2, Length: 16}
+	case AES_256bit:
+		this.SetVersion(2, 0)
+		crypter.V = 5
+		crypter.R = 6 // TODO(dennwc): a way to set R=5?
+		crypter.Length = 256
+		cf = CryptFilter{Cfm: CryptFilterAESV3, Length: 32}
+	default:
+		return fmt.Errorf("unsupported algorithm: %v", options.Algorithm)
+	}
+	const (
+		defaultFilter = "Default"
+	)
+	crypter.CryptFilters[defaultFilter] = cf
+	if crypter.V >= 4 {
+		crypter.StreamFilter = defaultFilter
+		crypter.StringFilter = defaultFilter
+	}
 
 	// Set
-	crypter.P = -1
-	crypter.V = 2
-	crypter.R = 3
-	crypter.Length = 128
+	crypter.P = math.MaxUint32
 	crypter.EncryptMetadata = true
 	if options != nil {
 		crypter.P = int(options.Permissions.GetP())
 	}
+
+	// Generate the encryption dictionary.
+	ed := MakeDict()
+	ed.Set("Filter", MakeName("Standard"))
+	ed.Set("P", MakeInteger(int64(crypter.P)))
+	ed.Set("V", MakeInteger(int64(crypter.V)))
+	ed.Set("R", MakeInteger(int64(crypter.R)))
+	ed.Set("Length", MakeInteger(int64(crypter.Length)))
+	this.encryptDict = ed
 
 	// Prepare the ID object for the trailer.
 	hashcode := md5.Sum([]byte(time.Now().Format(time.RFC850)))
@@ -510,38 +563,51 @@ func (this *PdfWriter) Encrypt(userPass, ownerPass []byte, options *EncryptOptio
 	this.ids = &PdfObjectArray{&id0, &id1}
 	common.Log.Trace("Gen Id 0: % x", id0)
 
-	crypter.Id0 = string(id0)
+	// Generate encryption parameters
+	if crypter.R < 5 {
+		crypter.Id0 = string(id0)
 
-	// Make the O and U objects.
-	O, err := crypter.Alg3(userPass, ownerPass)
-	if err != nil {
-		common.Log.Debug("ERROR: Error generating O for encryption (%s)", err)
-		return err
+		// Make the O and U objects.
+		O, err := crypter.Alg3(userPass, ownerPass)
+		if err != nil {
+			common.Log.Debug("ERROR: Error generating O for encryption (%s)", err)
+			return err
+		}
+		crypter.O = []byte(O)
+		common.Log.Trace("gen O: % x", O)
+		U, key, err := crypter.Alg5(userPass)
+		if err != nil {
+			common.Log.Debug("ERROR: Error generating O for encryption (%s)", err)
+			return err
+		}
+		common.Log.Trace("gen U: % x", U)
+		crypter.U = []byte(U)
+		crypter.EncryptionKey = key
+
+		ed.Set("O", &O)
+		ed.Set("U", &U)
+	} else { // R >= 5
+		err := crypter.GenerateParams(userPass, ownerPass)
+		if err != nil {
+			return err
+		}
+		ed.Set("O", MakeString(string(crypter.O)))
+		ed.Set("U", MakeString(string(crypter.U)))
+		ed.Set("OE", MakeString(string(crypter.OE)))
+		ed.Set("UE", MakeString(string(crypter.UE)))
+		ed.Set("EncryptMetadata", MakeBool(crypter.EncryptMetadata))
+		if crypter.R > 5 {
+			ed.Set("Perms", MakeString(string(crypter.Perms)))
+		}
 	}
-	crypter.O = []byte(O)
-	common.Log.Trace("gen O: % x", O)
-	U, key, err := crypter.Alg5(userPass)
-	if err != nil {
-		common.Log.Debug("ERROR: Error generating O for encryption (%s)", err)
-		return err
+	if crypter.V >= 4 {
+		if err := crypter.SaveCryptFilters(ed); err != nil {
+			return err
+		}
 	}
-	common.Log.Trace("gen U: % x", U)
-	crypter.U = []byte(U)
-	crypter.EncryptionKey = key
 
-	// Generate the encryption dictionary.
-	encDict := MakeDict()
-	encDict.Set("Filter", MakeName("Standard"))
-	encDict.Set("P", MakeInteger(int64(crypter.P)))
-	encDict.Set("V", MakeInteger(int64(crypter.V)))
-	encDict.Set("R", MakeInteger(int64(crypter.R)))
-	encDict.Set("Length", MakeInteger(int64(crypter.Length)))
-	encDict.Set("O", &O)
-	encDict.Set("U", &U)
-	this.encryptDict = encDict
-
-	// Make an object to contain it.
-	io := MakeIndirectObject(encDict)
+	// Make an object to contain the encryption dictionary.
+	io := MakeIndirectObject(ed)
 	this.encryptObj = io
 	this.addObject(io)
 

--- a/pdf/model/writer.go
+++ b/pdf/model/writer.go
@@ -527,7 +527,7 @@ func (this *PdfWriter) Encrypt(userPass, ownerPass []byte, options *EncryptOptio
 		return fmt.Errorf("unsupported algorithm: %v", options.Algorithm)
 	}
 	const (
-		defaultFilter = "Default"
+		defaultFilter = StandardCryptFilter
 	)
 	crypter.CryptFilters[defaultFilter] = cf
 	if crypter.V >= 4 {


### PR DESCRIPTION
PR implements the AESv3 (R=5-6) encryption.

It also exposes encryption algorithms AESv2 (128 bit, R=4) and AESv3 (256 bit, R=6 only) to the user by adding an `Algorithm` option to `EncryptionOptions`.

Resolves #198.