### PR TITLE
Refactor Crypt Filter Methods (CFM)

### DIFF
--- a/pdf/core/crypt.go
+++ b/pdf/core/crypt.go
@@ -591,46 +591,16 @@ func (crypt *PdfCrypt) paddedPass(pass []byte) []byte {
 func (crypt *PdfCrypt) makeKey(filter string, objNum, genNum uint32, ekey []byte) ([]byte, error) {
 	cf, ok := crypt.CryptFilters[filter]
 	if !ok {
-		common.Log.Debug("ERROR Unsupported crypt filter (%s)", filter)
-		return nil, fmt.Errorf("Unsupported crypt filter (%s)", filter)
+		err := fmt.Errorf("Unsupported crypt filter (%s)", filter)
+		common.Log.Debug("%s", err)
+		return nil, err
 	}
-	if cf.Cfm == CryptFilterAESV3 {
-		return ekey, nil
+	f, err := getCryptFilterMethod(cf.Cfm)
+	if err != nil {
+		common.Log.Debug("%s", err)
+		return nil, err
 	}
-	isAES2 := cf.Cfm == CryptFilterAESV2
-
-	key := make([]byte, len(ekey)+5)
-	for i := 0; i < len(ekey); i++ {
-		key[i] = ekey[i]
-	}
-	for i := 0; i < 3; i++ {
-		b := byte((objNum >> uint32(8*i)) & 0xff)
-		key[i+len(ekey)] = b
-	}
-	for i := 0; i < 2; i++ {
-		b := byte((genNum >> uint32(8*i)) & 0xff)
-		key[i+len(ekey)+3] = b
-	}
-	if isAES2 {
-		// If using the AES algorithm, extend the encryption key an
-		// additional 4 bytes by adding the value “sAlT”, which
-		// corresponds to the hexadecimal values 0x73, 0x41, 0x6C, 0x54.
-		key = append(key, 0x73)
-		key = append(key, 0x41)
-		key = append(key, 0x6C)
-		key = append(key, 0x54)
-	}
-
-	// Take the MD5.
-	h := md5.New()
-	h.Write(key)
-	hashb := h.Sum(nil)
-
-	if len(ekey)+5 < 16 {
-		return hashb[0 : len(ekey)+5], nil
-	}
-
-	return hashb, nil
+	return f.MakeKey(objNum, genNum, ekey)
 }
 
 // Check if object has already been processed.
@@ -653,80 +623,12 @@ func (crypt *PdfCrypt) decryptBytes(buf []byte, filter string, okey []byte) ([]b
 		common.Log.Debug("ERROR Unsupported crypt filter (%s)", filter)
 		return nil, fmt.Errorf("Unsupported crypt filter (%s)", filter)
 	}
-
-	cfMethod := cf.Cfm
-	if cfMethod == CryptFilterV2 {
-		// Standard RC4 algorithm.
-		ciph, err := rc4.NewCipher(okey)
-		if err != nil {
-			return nil, err
-		}
-		common.Log.Trace("RC4 Decrypt: % x", buf)
-		ciph.XORKeyStream(buf, buf)
-		common.Log.Trace("to: % x", buf)
-		return buf, nil
-	} else if cfMethod == CryptFilterAESV2 || cfMethod == CryptFilterAESV3 {
-		// Strings and streams encrypted with AES shall use a padding
-		// scheme that is described in Internet RFC 2898, PKCS #5:
-		// Password-Based Cryptography Specification Version 2.0; see
-		// the Bibliography. For an original message length of M,
-		// the pad shall consist of 16 - (M mod 16) bytes whose value
-		// shall also be 16 - (M mod 16).
-		//
-		// A 9-byte message has a pad of 7 bytes, each with the value
-		// 0x07. The pad can be unambiguously removed to determine the
-		// original message length when decrypting. Note that the pad is
-		// present when M is evenly divisible by 16; it contains 16 bytes
-		// of 0x10.
-
-		ciph, err := aes.NewCipher(okey)
-		if err != nil {
-			return nil, err
-		}
-
-		// If using the AES algorithm, the Cipher Block Chaining (CBC)
-		// mode, which requires an initialization vector, is used. The
-		// block size parameter is set to 16 bytes, and the initialization
-		// vector is a 16-byte random number that is stored as the first
-		// 16 bytes of the encrypted stream or string.
-		if len(buf) < 16 {
-			common.Log.Debug("ERROR AES invalid buf %s", buf)
-			return buf, fmt.Errorf("AES: Buf len < 16 (%d)", len(buf))
-		}
-
-		iv := buf[:16]
-		buf = buf[16:]
-
-		if len(buf)%16 != 0 {
-			common.Log.Debug(" iv (%d): % x", len(iv), iv)
-			common.Log.Debug("buf (%d): % x", len(buf), buf)
-			return buf, fmt.Errorf("AES buf length not multiple of 16 (%d)", len(buf))
-		}
-
-		mode := cipher.NewCBCDecrypter(ciph, iv)
-
-		common.Log.Trace("AES Decrypt (%d): % x", len(buf), buf)
-		common.Log.Trace("chop AES Decrypt (%d): % x", len(buf), buf)
-		mode.CryptBlocks(buf, buf)
-		common.Log.Trace("to (%d): % x", len(buf), buf)
-
-		if len(buf) == 0 {
-			common.Log.Trace("Empty buf, returning empty string")
-			return buf, nil
-		}
-
-		// The padded length is indicated by the last values.  Remove those.
-
-		padLen := int(buf[len(buf)-1])
-		if padLen >= len(buf) {
-			common.Log.Debug("Illegal pad length")
-			return buf, fmt.Errorf("Invalid pad length for %s", cfMethod)
-		}
-		buf = buf[:len(buf)-padLen]
-
-		return buf, nil
+	f, err := getCryptFilterMethod(cf.Cfm)
+	if err != nil {
+		common.Log.Debug("%s", err)
+		return nil, err
 	}
-	return nil, fmt.Errorf("Unsupported crypt filter method (%s)", cfMethod)
+	return f.DecryptBytes(buf, okey)
 }
 
 // Decrypt an object with specified key. For numbered objects,
@@ -911,69 +813,12 @@ func (crypt *PdfCrypt) encryptBytes(buf []byte, filter string, okey []byte) ([]b
 		common.Log.Debug("ERROR Unsupported crypt filter (%s)", filter)
 		return nil, fmt.Errorf("Unsupported crypt filter (%s)", filter)
 	}
-
-	cfMethod := cf.Cfm
-	if cfMethod == CryptFilterV2 {
-		// Standard RC4 algorithm.
-		ciph, err := rc4.NewCipher(okey)
-		if err != nil {
-			return nil, err
-		}
-		common.Log.Trace("RC4 Encrypt: % x", buf)
-		ciph.XORKeyStream(buf, buf)
-		common.Log.Trace("to: % x", buf)
-		return buf, nil
-	} else if cfMethod == CryptFilterAESV2 || cfMethod == CryptFilterAESV3 {
-		// Strings and streams encrypted with AES shall use a padding
-		// scheme that is described in Internet RFC 2898, PKCS #5:
-		// Password-Based Cryptography Specification Version 2.0; see
-		// the Bibliography. For an original message length of M,
-		// the pad shall consist of 16 - (M mod 16) bytes whose value
-		// shall also be 16 - (M mod 16).
-		//
-		// A 9-byte message has a pad of 7 bytes, each with the value
-		// 0x07. The pad can be unambiguously removed to determine the
-		// original message length when decrypting. Note that the pad is
-		// present when M is evenly divisible by 16; it contains 16 bytes
-		// of 0x10.
-
-		ciph, err := aes.NewCipher(okey)
-		if err != nil {
-			return nil, err
-		}
-
-		common.Log.Trace("AES Encrypt (%d): % x", len(buf), buf)
-
-		// If using the AES algorithm, the Cipher Block Chaining (CBC)
-		// mode, which requires an initialization vector, is used. The
-		// block size parameter is set to 16 bytes, and the initialization
-		// vector is a 16-byte random number that is stored as the first
-		// 16 bytes of the encrypted stream or string.
-
-		const block = aes.BlockSize // 16
-
-		pad := block - len(buf)%block
-		for i := 0; i < pad; i++ {
-			buf = append(buf, byte(pad))
-		}
-		common.Log.Trace("Padded to %d bytes", len(buf))
-
-		// Generate random 16 bytes, place in beginning of buffer.
-		ciphertext := make([]byte, block+len(buf))
-		iv := ciphertext[:block]
-		if _, err := io.ReadFull(rand.Reader, iv); err != nil {
-			return nil, err
-		}
-
-		mode := cipher.NewCBCEncrypter(ciph, iv)
-		mode.CryptBlocks(ciphertext[block:], buf)
-
-		buf = ciphertext
-		common.Log.Trace("to (%d): % x", len(buf), buf)
-
-		return buf, nil
+	f, err := getCryptFilterMethod(cf.Cfm)
+	if err != nil {
+		common.Log.Debug("%s", err)
+		return nil, err
 	}
-	return nil, fmt.Errorf("Unsupported crypt filter method (%s)", cfMethod)
+	return f.EncryptBytes(buf, okey)
 }
 
 // Encrypt an object with specified key. For numbered objects,

--- a/pdf/core/crypt_filters.go
+++ b/pdf/core/crypt_filters.go
@@ -1,0 +1,270 @@
+package core
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/rc4"
+	"fmt"
+	"io"
+
+	"github.com/unidoc/unidoc/common"
+)
+
+var (
+	cryptMethods = make(map[string]cryptFilterMethod)
+)
+
+func registerCryptFilterMethod(m cryptFilterMethod) {
+	cryptMethods[m.CFM()] = m
+}
+
+func getCryptFilterMethod(name string) (cryptFilterMethod, error) {
+	f := cryptMethods[name]
+	if f == nil {
+		return nil, fmt.Errorf("unsupported crypt filter: %q", name)
+	}
+	return f, nil
+}
+
+func init() {
+	registerCryptFilterMethod(cryptFilterV2{})
+	registerCryptFilterMethod(cryptFilterAESV2{})
+	registerCryptFilterMethod(cryptFilterAESV3{})
+}
+
+type cryptFilterMethod interface {
+	CFM() string
+	MakeKey(objNum, genNum uint32, fkey []byte) ([]byte, error)
+	EncryptBytes(p []byte, okey []byte) ([]byte, error)
+	DecryptBytes(p []byte, okey []byte) ([]byte, error)
+}
+
+// cryptFilterV2 is a RC4-based filter
+type cryptFilterV2 struct{}
+
+func (cryptFilterV2) CFM() string {
+	return CryptFilterV2
+}
+
+func (f cryptFilterV2) MakeKey(objNum, genNum uint32, ekey []byte) ([]byte, error) {
+	key := make([]byte, len(ekey)+5)
+	for i := 0; i < len(ekey); i++ {
+		key[i] = ekey[i]
+	}
+	for i := 0; i < 3; i++ {
+		b := byte((objNum >> uint32(8*i)) & 0xff)
+		key[i+len(ekey)] = b
+	}
+	for i := 0; i < 2; i++ {
+		b := byte((genNum >> uint32(8*i)) & 0xff)
+		key[i+len(ekey)+3] = b
+	}
+
+	// Take the MD5.
+	h := md5.New()
+	h.Write(key)
+	hashb := h.Sum(nil)
+
+	if len(ekey)+5 < 16 {
+		return hashb[0 : len(ekey)+5], nil
+	}
+
+	return hashb, nil
+}
+
+func (cryptFilterV2) EncryptBytes(buf []byte, okey []byte) ([]byte, error) {
+	// Standard RC4 algorithm.
+	ciph, err := rc4.NewCipher(okey)
+	if err != nil {
+		return nil, err
+	}
+	common.Log.Trace("RC4 Encrypt: % x", buf)
+	ciph.XORKeyStream(buf, buf)
+	common.Log.Trace("to: % x", buf)
+	return buf, nil
+}
+
+func (cryptFilterV2) DecryptBytes(buf []byte, okey []byte) ([]byte, error) {
+	// Standard RC4 algorithm.
+	ciph, err := rc4.NewCipher(okey)
+	if err != nil {
+		return nil, err
+	}
+	common.Log.Trace("RC4 Decrypt: % x", buf)
+	ciph.XORKeyStream(buf, buf)
+	common.Log.Trace("to: % x", buf)
+	return buf, nil
+}
+
+// cryptFilterAES implements a generic AES encryption and decryption algorithm used by AESV2 and AESV3 filter methods.
+type cryptFilterAES struct{}
+
+func (cryptFilterAES) EncryptBytes(buf []byte, okey []byte) ([]byte, error) {
+	// Strings and streams encrypted with AES shall use a padding
+	// scheme that is described in Internet RFC 2898, PKCS #5:
+	// Password-Based Cryptography Specification Version 2.0; see
+	// the Bibliography. For an original message length of M,
+	// the pad shall consist of 16 - (M mod 16) bytes whose value
+	// shall also be 16 - (M mod 16).
+	//
+	// A 9-byte message has a pad of 7 bytes, each with the value
+	// 0x07. The pad can be unambiguously removed to determine the
+	// original message length when decrypting. Note that the pad is
+	// present when M is evenly divisible by 16; it contains 16 bytes
+	// of 0x10.
+
+	ciph, err := aes.NewCipher(okey)
+	if err != nil {
+		return nil, err
+	}
+
+	common.Log.Trace("AES Encrypt (%d): % x", len(buf), buf)
+
+	// If using the AES algorithm, the Cipher Block Chaining (CBC)
+	// mode, which requires an initialization vector, is used. The
+	// block size parameter is set to 16 bytes, and the initialization
+	// vector is a 16-byte random number that is stored as the first
+	// 16 bytes of the encrypted stream or string.
+
+	const block = aes.BlockSize // 16
+
+	pad := block - len(buf)%block
+	for i := 0; i < pad; i++ {
+		buf = append(buf, byte(pad))
+	}
+	common.Log.Trace("Padded to %d bytes", len(buf))
+
+	// Generate random 16 bytes, place in beginning of buffer.
+	ciphertext := make([]byte, block+len(buf))
+	iv := ciphertext[:block]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, err
+	}
+
+	mode := cipher.NewCBCEncrypter(ciph, iv)
+	mode.CryptBlocks(ciphertext[block:], buf)
+
+	buf = ciphertext
+	common.Log.Trace("to (%d): % x", len(buf), buf)
+
+	return buf, nil
+}
+
+func (cryptFilterAES) DecryptBytes(buf []byte, okey []byte) ([]byte, error) {
+	// Strings and streams encrypted with AES shall use a padding
+	// scheme that is described in Internet RFC 2898, PKCS #5:
+	// Password-Based Cryptography Specification Version 2.0; see
+	// the Bibliography. For an original message length of M,
+	// the pad shall consist of 16 - (M mod 16) bytes whose value
+	// shall also be 16 - (M mod 16).
+	//
+	// A 9-byte message has a pad of 7 bytes, each with the value
+	// 0x07. The pad can be unambiguously removed to determine the
+	// original message length when decrypting. Note that the pad is
+	// present when M is evenly divisible by 16; it contains 16 bytes
+	// of 0x10.
+
+	ciph, err := aes.NewCipher(okey)
+	if err != nil {
+		return nil, err
+	}
+
+	// If using the AES algorithm, the Cipher Block Chaining (CBC)
+	// mode, which requires an initialization vector, is used. The
+	// block size parameter is set to 16 bytes, and the initialization
+	// vector is a 16-byte random number that is stored as the first
+	// 16 bytes of the encrypted stream or string.
+	if len(buf) < 16 {
+		common.Log.Debug("ERROR AES invalid buf %s", buf)
+		return buf, fmt.Errorf("AES: Buf len < 16 (%d)", len(buf))
+	}
+
+	iv := buf[:16]
+	buf = buf[16:]
+
+	if len(buf)%16 != 0 {
+		common.Log.Debug(" iv (%d): % x", len(iv), iv)
+		common.Log.Debug("buf (%d): % x", len(buf), buf)
+		return buf, fmt.Errorf("AES buf length not multiple of 16 (%d)", len(buf))
+	}
+
+	mode := cipher.NewCBCDecrypter(ciph, iv)
+
+	common.Log.Trace("AES Decrypt (%d): % x", len(buf), buf)
+	common.Log.Trace("chop AES Decrypt (%d): % x", len(buf), buf)
+	mode.CryptBlocks(buf, buf)
+	common.Log.Trace("to (%d): % x", len(buf), buf)
+
+	if len(buf) == 0 {
+		common.Log.Trace("Empty buf, returning empty string")
+		return buf, nil
+	}
+
+	// The padded length is indicated by the last values.  Remove those.
+
+	padLen := int(buf[len(buf)-1])
+	if padLen >= len(buf) {
+		common.Log.Debug("Illegal pad length")
+		return buf, fmt.Errorf("Invalid pad length")
+	}
+	buf = buf[:len(buf)-padLen]
+
+	return buf, nil
+}
+
+// cryptFilterAESV2 is an AES-based filter (128 bit key, PDF 1.6)
+type cryptFilterAESV2 struct {
+	cryptFilterAES
+}
+
+func (cryptFilterAESV2) CFM() string {
+	return CryptFilterAESV2
+}
+
+func (cryptFilterAESV2) MakeKey(objNum, genNum uint32, ekey []byte) ([]byte, error) {
+	key := make([]byte, len(ekey)+5)
+	for i := 0; i < len(ekey); i++ {
+		key[i] = ekey[i]
+	}
+	for i := 0; i < 3; i++ {
+		b := byte((objNum >> uint32(8*i)) & 0xff)
+		key[i+len(ekey)] = b
+	}
+	for i := 0; i < 2; i++ {
+		b := byte((genNum >> uint32(8*i)) & 0xff)
+		key[i+len(ekey)+3] = b
+	}
+	// If using the AES algorithm, extend the encryption key an
+	// additional 4 bytes by adding the value “sAlT”, which
+	// corresponds to the hexadecimal values 0x73, 0x41, 0x6C, 0x54.
+	key = append(key, 0x73)
+	key = append(key, 0x41)
+	key = append(key, 0x6C)
+	key = append(key, 0x54)
+
+	// Take the MD5.
+	h := md5.New()
+	h.Write(key)
+	hashb := h.Sum(nil)
+
+	if len(ekey)+5 < 16 {
+		return hashb[0 : len(ekey)+5], nil
+	}
+
+	return hashb, nil
+}
+
+// cryptFilterAESV3 is an AES-based filter (256 bit key, PDF 2.0)
+type cryptFilterAESV3 struct {
+	cryptFilterAES
+}
+
+func (cryptFilterAESV3) CFM() string {
+	return CryptFilterAESV3
+}
+
+func (cryptFilterAESV3) MakeKey(_, _ uint32, ekey []byte) ([]byte, error) {
+	return ekey, nil
+}

--- a/pdf/core/crypt_test.go
+++ b/pdf/core/crypt_test.go
@@ -148,8 +148,7 @@ func TestDecryption1(t *testing.T) {
 	crypter := PdfCrypt{}
 	crypter.DecryptedObjects = map[PdfObject]bool{}
 	// Default algorithm is V2 (RC4).
-	crypter.CryptFilters = CryptFilters{}
-	crypter.CryptFilters[StandardCryptFilter] = CryptFilter{Cfm: "V2", Length: crypter.Length}
+	crypter.CryptFilters = newCryptFiltersV2(crypter.Length)
 	crypter.V = 2
 	crypter.R = 3
 	crypter.P = -3904

--- a/pdf/model/writer.go
+++ b/pdf/model/writer.go
@@ -509,23 +509,22 @@ func (this *PdfWriter) Encrypt(userPass, ownerPass []byte, options *EncryptOptio
 	case RC4_128bit:
 		crypter.V = 2
 		crypter.R = 3
-		crypter.Length = 128
-		cf = CryptFilter{Cfm: CryptFilterV2, Length: 16}
+		cf = NewCryptFilterV2(16)
 	case AES_128bit:
 		this.SetVersion(1, 5)
 		crypter.V = 4
 		crypter.R = 4
-		crypter.Length = 128
-		cf = CryptFilter{Cfm: CryptFilterAESV2, Length: 16}
+		cf = NewCryptFilterAESV2()
 	case AES_256bit:
 		this.SetVersion(2, 0)
 		crypter.V = 5
 		crypter.R = 6 // TODO(dennwc): a way to set R=5?
-		crypter.Length = 256
-		cf = CryptFilter{Cfm: CryptFilterAESV3, Length: 32}
+		cf = NewCryptFilterAESV3()
 	default:
 		return fmt.Errorf("unsupported algorithm: %v", options.Algorithm)
 	}
+	crypter.Length = cf.Length * 8
+
 	const (
 		defaultFilter = StandardCryptFilter
 	)


### PR DESCRIPTION
Move CFMs to separate objects that implement a common interface.

Further refactoring can be done on `v3` branch.