### PR TITLE
Expose Numeric PdfVersion

### DIFF
--- a/pdf/core/parser.go
+++ b/pdf/core/parser.go
@@ -59,6 +59,11 @@ func (parser *PdfParser) PdfVersion() string {
 	return fmt.Sprintf("%0d.%0d", parser.majorVersion, parser.minorVersion)
 }
 
+// PdfVersionInt returns version of the PDF file.
+func (parser *PdfParser) PdfVersionInt() (int, int) {
+	return parser.majorVersion, parser.minorVersion
+}
+
 // GetCrypter returns the PdfCrypt instance which has information about the PDFs encryption.
 func (parser *PdfParser) GetCrypter() *PdfCrypt {
 	return parser.crypter

--- a/pdf/model/reader.go
+++ b/pdf/model/reader.go
@@ -71,6 +71,11 @@ func (this *PdfReader) PdfVersion() string {
 	return this.parser.PdfVersion()
 }
 
+// PdfVersionInt returns version of the PDF file.
+func (this *PdfReader) PdfVersionInt() (int, int) {
+	return this.parser.PdfVersionInt()
+}
+
 // IsEncrypted returns true if the PDF file is encrypted.
 func (this *PdfReader) IsEncrypted() (bool, error) {
 	return this.parser.IsEncrypted()


### PR DESCRIPTION
Would it be ok to expose the PdfVersion to easily copy to the destination document?

https://github.com/a1comms/pdf-api/blob/cf11daa9c35c2dc88eebc06b12ccffab33db4d1b/model_pdf_merge.go#L38