### PR TITLE
Fix styled paragraph newline text wrapping

### DIFF
--- a/pdf/creator/styled_paragraph.go
+++ b/pdf/creator/styled_paragraph.go
@@ -281,7 +281,7 @@ func (p *StyledParagraph) wrapText() error {
 			}
 
 			// newline wrapping.
-			if glyph == "controllf" {
+			if glyph == "controlLF" {
 				// moves to next line.
 				line = append(line, TextChunk{
 					Text:  strings.TrimRightFunc(string(part), unicode.IsSpace),


### PR DESCRIPTION
Fixes a typo which causes text wrapping on newline character to work incorrectly.