### PR TITLE
Wrap paragraph text only if width has been set

### DIFF
--- a/pdf/creator/creator_test.go
+++ b/pdf/creator/creator_test.go
@@ -1855,6 +1855,7 @@ func TestTableInSubchapter(t *testing.T) {
 	cell.SetIndent(5)
 
 	p = NewParagraph("Bezt business bureu")
+	p.SetEnableWrap(false)
 	p.SetFont(fontRegular)
 	p.SetFontSize(10)
 	p.SetColor(ColorGreen)

--- a/pdf/creator/division_test.go
+++ b/pdf/creator/division_test.go
@@ -139,13 +139,14 @@ func TestDivInline(t *testing.T) {
 	style.Color = ColorRGBFrom8bit(0, 0, 255)
 
 	s := NewStyledParagraph("This styled paragraph should ", style)
+	s.SetEnableWrap(false)
 
 	style.Color = ColorRGBFrom8bit(255, 0, 0)
 	s.Append("fit", style)
 
 	style.Color = ColorRGBFrom8bit(0, 255, 0)
 	style.Font = fontBold
-	s.Append(" right in.", style)
+	s.Append(" in.", style)
 
 	div.Add(s)
 

--- a/pdf/creator/paragraph.go
+++ b/pdf/creator/paragraph.go
@@ -85,7 +85,7 @@ func NewParagraph(text string) *Paragraph {
 
 	// TODO: Can we wrap intellectually, only if given width is known?
 
-	p.enableWrap = false
+	p.enableWrap = true
 	p.defaultWrap = true
 	p.SetColor(ColorRGBFrom8bit(0, 0, 0))
 	p.alignment = TextAlignmentLeft
@@ -187,13 +187,12 @@ func (p *Paragraph) GetMargins() (float64, float64, float64, float64) {
 // text can extend to prior to wrapping over to next line.
 func (p *Paragraph) SetWidth(width float64) {
 	p.wrapWidth = width
-	p.enableWrap = true
 	p.wrapText()
 }
 
 // Width returns the width of the Paragraph.
 func (p *Paragraph) Width() float64 {
-	if p.enableWrap {
+	if p.enableWrap && int(p.wrapWidth) > 0 {
 		return p.wrapWidth
 	}
 	return p.getTextWidth() / 1000.0
@@ -239,7 +238,7 @@ func (p *Paragraph) getTextWidth() float64 {
 // Simple algorithm to wrap the text into lines (greedy algorithm - fill the lines).
 // XXX/TODO: Consider the Knuth/Plass algorithm or an alternative.
 func (p *Paragraph) wrapText() error {
-	if !p.enableWrap {
+	if !p.enableWrap || int(p.wrapWidth) <= 0 {
 		p.textLines = []string{p.text}
 		return nil
 	}
@@ -367,7 +366,7 @@ func (p *Paragraph) GeneratePageBlocks(ctx DrawContext) ([]*Block, DrawContext, 
 		}
 	} else {
 		// Absolute.
-		if p.wrapWidth == 0 {
+		if int(p.wrapWidth) <= 0 {
 			// Use necessary space.
 			p.SetWidth(p.getTextWidth())
 		}

--- a/pdf/creator/table.go
+++ b/pdf/creator/table.go
@@ -691,15 +691,15 @@ func (cell *TableCell) SetContent(vd VectorDrawable) error {
 	switch t := vd.(type) {
 	case *Paragraph:
 		if t.defaultWrap {
-			// Default paragraph settings in table: no wrapping.
-			t.enableWrap = false // No wrapping.
+			// Enable wrapping by default.
+			t.enableWrap = true
 		}
 
 		cell.content = vd
 	case *StyledParagraph:
 		if t.defaultWrap {
-			// Default styled paragraph settings in table: no wrapping.
-			t.enableWrap = false // No wrapping.
+			// Enable wrapping by default.
+			t.enableWrap = true
 		}
 
 		cell.content = vd


### PR DESCRIPTION
Wrap text in paragraph/styled paragraph only if wrapping is enabled and the wrap width is larger than 0.
Enable paragraph/styled paragraph wrapping by default.