### PR TITLE
TTF parser fixes and tests

### DIFF
--- a/pdf/model/fonts/ttfparser.go
+++ b/pdf/model/fonts/ttfparser.go
@@ -70,7 +70,6 @@ func (rec *TtfType) MakeEncoder() (*textencoding.SimpleEncoder, error) {
 // TtfType describes a TrueType font file.
 // http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=iws-chapter08
 type TtfType struct {
-	Embeddable             bool
 	UnitsPerEm             uint16
 	PostScriptName         string
 	Bold                   bool
@@ -111,9 +110,9 @@ func (ttf *TtfType) MakeToUnicode() *cmap.CMap {
 
 // String returns a human readable representation of `ttf`.
 func (ttf *TtfType) String() string {
-	return fmt.Sprintf("FONT_FILE2{%#q Embeddable=%t UnitsPerEm=%d Bold=%t ItalicAngle=%f "+
+	return fmt.Sprintf("FONT_FILE2{%#q UnitsPerEm=%d Bold=%t ItalicAngle=%f "+
 		"CapHeight=%d Chars=%d GlyphNames=%d}",
-		ttf.PostScriptName, ttf.Embeddable, ttf.UnitsPerEm, ttf.Bold, ttf.ItalicAngle,
+		ttf.PostScriptName, ttf.UnitsPerEm, ttf.Bold, ttf.ItalicAngle,
 		ttf.CapHeight, len(ttf.Chars), len(ttf.GlyphNames))
 }
 
@@ -607,9 +606,7 @@ func (t *ttfParser) ParseOS2() error {
 		return err
 	}
 	version := t.ReadUShort()
-	t.Skip(3 * 2) // xAvgCharWidth, usWeightClass, usWidthClass
-	fsType := t.ReadUShort()
-	t.rec.Embeddable = (fsType != 2) && (fsType&0x200) == 0
+	t.Skip(4 * 2) // xAvgCharWidth, usWeightClass, usWidthClass
 	t.Skip(11*2 + 10 + 4*4 + 4)
 	fsSelection := t.ReadUShort()
 	t.rec.Bold = (fsSelection & 32) != 0

--- a/pdf/model/fonts/ttfparser.go
+++ b/pdf/model/fonts/ttfparser.go
@@ -53,7 +53,7 @@ func (rec *TtfType) MakeEncoder() (*textencoding.SimpleEncoder, error) {
 			continue
 		}
 		glyph := ""
-		if 0 <= gid && int(gid) < len(rec.GlyphNames) {
+		if int(gid) >= 0 && int(gid) < len(rec.GlyphNames) {
 			glyph = rec.GlyphNames[gid]
 		} else {
 			glyph = string(rune(gid))

--- a/pdf/model/fonts/ttfparser.go
+++ b/pdf/model/fonts/ttfparser.go
@@ -806,7 +806,7 @@ func (t *ttfParser) ReadULong() (val uint32) {
 // ReadULong reads 4 bytes and returns them as a float, the first 2 bytes for the whole number and
 // the second 2 bytes for the fraction.
 func (t *ttfParser) Read32Fixed() float64 {
-	whole := float64(t.ReadUShort())
+	whole := float64(t.ReadShort())
 	frac := float64(t.ReadUShort()) / 65536.0
 	return whole + frac
 }

--- a/pdf/model/fonts/ttfparser_test.go
+++ b/pdf/model/fonts/ttfparser_test.go
@@ -1,0 +1,124 @@
+package fonts
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/unidoc/unidoc/pdf/internal/textencoding"
+)
+
+const fontDir = `../../creator/testdata`
+
+var casesTTFParse = []struct {
+	path         string
+	name         string
+	bold         bool
+	italicAngle  float32
+	underlinePos int16
+	underlineTh  int16
+	isFixed      bool
+	bbox         [4]int
+	runes        map[rune]uint16
+	widths       map[rune]int
+}{
+	{
+		path:         "FreeSans.ttf",
+		name:         "FreeSans",
+		underlinePos: -151,
+		underlineTh:  50,
+		bbox:         [4]int{-631, 1632, -462, 1230},
+		runes: map[rune]uint16{
+			'x': 0x5d,
+			'ё': 0x32a,
+		},
+		widths: map[rune]int{
+			'x': 500,
+			'ё': 556,
+		},
+	},
+	{
+		path:         "roboto/Roboto-Bold.ttf",
+		name:         "Roboto-Bold",
+		bold:         true,
+		underlinePos: -150,
+		underlineTh:  100,
+		bbox:         [4]int{-1488, 2439, -555, 2163},
+		runes: map[rune]uint16{
+			'x': 0x5c,
+			'ё': 0x3cb,
+		},
+		widths: map[rune]int{
+			'x': 1042,
+			'ё': 1107,
+		},
+	},
+	{
+		path:         "roboto/Roboto-BoldItalic.ttf",
+		name:         "Roboto-BoldItalic",
+		bold:         true,
+		italicAngle:  -12,
+		underlinePos: -150,
+		underlineTh:  100,
+		bbox:         [4]int{-1459, 2467, -555, 2163},
+		runes: map[rune]uint16{
+			'x': 0x5c,
+			'ё': 0x3cb,
+		},
+		widths: map[rune]int{
+			'x': 1021,
+			'ё': 1084,
+		},
+	},
+}
+
+var testRunes = []rune{'x', 'ё'}
+
+func TestTTFParse(t *testing.T) {
+	for _, c := range casesTTFParse {
+		t.Run(c.path, func(t *testing.T) {
+			path := filepath.Join(fontDir, c.path)
+
+			ft, err := TtfParse(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ft.Bold != c.bold {
+				t.Error(ft.Bold, c.bold)
+			}
+			if float32(ft.ItalicAngle) != c.italicAngle {
+				t.Error(ft.ItalicAngle, c.italicAngle)
+			}
+			if ft.UnderlinePosition != c.underlinePos {
+				t.Error(ft.UnderlinePosition, c.underlinePos)
+			}
+			if ft.UnderlineThickness != c.underlineTh {
+				t.Error(ft.UnderlineThickness, c.underlineTh)
+			}
+			if ft.IsFixedPitch != c.isFixed {
+				t.Error(ft.IsFixedPitch, c.isFixed)
+			}
+			if b := [4]int{int(ft.Xmin), int(ft.Xmax), int(ft.Ymin), int(ft.Ymax)}; b != c.bbox {
+				t.Error(b, c.bbox)
+			}
+			if ft.PostScriptName != c.name {
+				t.Errorf("%q %q", ft.PostScriptName, c.name)
+			}
+			enc := textencoding.NewTrueTypeFontEncoder(ft.Chars)
+
+			for _, r := range testRunes {
+				t.Run(string(r), func(t *testing.T) {
+					ind, ok := enc.RuneToCharcode(r)
+					if !ok {
+						t.Fatal("no char")
+					} else if ind != c.runes[r] {
+						t.Fatalf("%x != %x", ind, c.runes[r])
+					}
+					w := ft.Widths[ft.Chars[uint16(r)]]
+					if int(w) != c.widths[r] {
+						t.Errorf("%d != %d", int(w), c.widths[r])
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backport few fixes to the `font` package discovered while testing against `x/image/font` library:

* Remove `Embeddable` field from `TtfType` (unused)
* Fix bounds check in GID-to-names mapper (unsigned < zero)
* Fix `ItalicAngle` value (floats are signed)
* Add tests for the TTF parser