### PR TITLE
Remove panics from crypto code, simplify the code

### DIFF
--- a/pdf/core/security/handlers.go
+++ b/pdf/core/security/handlers.go
@@ -5,6 +5,8 @@
 
 package security
 
+import "fmt"
+
 // StdHandler is an interface for standard security handlers.
 type StdHandler interface {
 	// GenerateParams uses owner and user passwords to set encryption parameters and generate an encryption key.
@@ -29,4 +31,23 @@ type StdEncryptDict struct {
 	O, U   []byte
 	OE, UE []byte // R=6
 	Perms  []byte // An encrypted copy of P (16 bytes). Used to verify permissions. R=6
+}
+
+// checkAtLeast checks the size of the bytes field and returns a descriptive error if it doesn't.
+func checkAtLeast(fnc, field string, exp int, b []byte) error {
+	if len(b) < exp {
+		return errInvalidField{Func: fnc, Field: field, Exp: exp, Got: len(b)}
+	}
+	return nil
+}
+
+type errInvalidField struct {
+	Func  string
+	Field string
+	Exp   int
+	Got   int
+}
+
+func (e errInvalidField) Error() string {
+	return fmt.Sprintf("%s: expected %s field to be %d bytes, got %d", e.Func, e.Field, e.Exp, e.Got)
 }

--- a/pdf/core/security/standard_r4.go
+++ b/pdf/core/security/standard_r4.go
@@ -35,19 +35,11 @@ type stdHandlerR4 struct {
 	ID0    string
 }
 
-func (sh stdHandlerR4) paddedPass(pass []byte) []byte {
+func (stdHandlerR4) paddedPass(pass []byte) []byte {
 	key := make([]byte, 32)
-	if len(pass) >= 32 {
-		for i := 0; i < 32; i++ {
-			key[i] = pass[i]
-		}
-	} else {
-		for i := 0; i < len(pass); i++ {
-			key[i] = pass[i]
-		}
-		for i := len(pass); i < 32; i++ {
-			key[i] = padding[i-len(pass)]
-		}
+	i := copy(key, pass)
+	for ; i < 32; i++ {
+		key[i] = padding[i-len(pass)]
 	}
 	return key
 }


### PR DESCRIPTION
* Remove panics from R=6 security handlers, validate fields before using.
* Simplify the code of R=4 security handlers (replace loops with stdlib functions).