### PR TITLE
Use os.TempDir instead of /tmp directly for all generated pdfs in cre…

### DIFF
--- a/pdf/creator/border_test.go
+++ b/pdf/creator/border_test.go
@@ -32,7 +32,7 @@ func TestSingleBorder(t *testing.T) {
 	c := New()
 	c.Draw(border)
 
-	err := c.WriteToFile("/tmp/border_single.pdf")
+	err := c.WriteToFile(tempFile("border_single.pdf"))
 	if err != nil {
 		t.Errorf("Fail: %v\n", err)
 		return
@@ -54,7 +54,7 @@ func TestSingleBorder2(t *testing.T) {
 	c := New()
 	c.Draw(border)
 
-	err := c.WriteToFile("/tmp/border_single2.pdf")
+	err := c.WriteToFile(tempFile("border_single2.pdf"))
 	if err != nil {
 		t.Errorf("Fail: %v\n", err)
 		return
@@ -76,7 +76,7 @@ func TestSingleBorder3(t *testing.T) {
 	c := New()
 	c.Draw(border)
 
-	err := c.WriteToFile("/tmp/border_single3.pdf")
+	err := c.WriteToFile(tempFile("border_single3.pdf"))
 	if err != nil {
 		t.Errorf("Fail: %v\n", err)
 		return
@@ -105,7 +105,7 @@ func TestSingleBorder4(t *testing.T) {
 	c := New()
 	c.Draw(border)
 
-	err := c.WriteToFile("/tmp/border_single4.pdf")
+	err := c.WriteToFile(tempFile("border_single4.pdf"))
 	if err != nil {
 		t.Errorf("Fail: %v\n", err)
 		return

--- a/pdf/creator/curve_test.go
+++ b/pdf/creator/curve_test.go
@@ -19,7 +19,7 @@ func TestNewCurve(t *testing.T) {
 		return
 	}
 
-	err = creator.WriteToFile("/tmp/curve.pdf")
+	err = creator.WriteToFile(tempFile("curve.pdf"))
 	if err != nil {
 		t.Errorf("Fail: %v", err)
 		return
@@ -63,7 +63,7 @@ func TestNewCurveWithGlass(t *testing.T) {
 	creator.Draw(CreateCurve(creator, 51, 399, 75, 445, 150, 450, ColorRed))
 	creator.Draw(CreateCurve(creator, 150, 450, 225, 445, 251, 399, ColorGreen))
 
-	err := creator.WriteToFile("/tmp/curve_glass.pdf")
+	err := creator.WriteToFile(tempFile("curve_glass.pdf"))
 	if err != nil {
 		t.Errorf("Fail: %v", err)
 		return

--- a/pdf/creator/division_test.go
+++ b/pdf/creator/division_test.go
@@ -86,7 +86,7 @@ func TestDivVertical(t *testing.T) {
 	}
 
 	// Write output file.
-	err = c.WriteToFile("/tmp/division_vertical.pdf")
+	err = c.WriteToFile(tempFile("division_vertical.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}
@@ -164,7 +164,7 @@ func TestDivInline(t *testing.T) {
 	}
 
 	// Write output file.
-	err = c.WriteToFile("/tmp/division_inline.pdf")
+	err = c.WriteToFile(tempFile("division_inline.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}
@@ -215,7 +215,7 @@ func TestDivNumberMatrix(t *testing.T) {
 	}
 
 	// Write output file.
-	err = c.WriteToFile("/tmp/division_number_matrix.pdf")
+	err = c.WriteToFile(tempFile("division_number_matrix.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}
@@ -291,7 +291,7 @@ func TestDivRandomSequences(t *testing.T) {
 	}
 
 	// Write output file.
-	err = c.WriteToFile("/tmp/division_random_sequences.pdf")
+	err = c.WriteToFile(tempFile("division_random_sequences.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}
@@ -367,7 +367,7 @@ func TestTableDivisions(t *testing.T) {
 	}
 
 	// Write output file.
-	err = c.WriteToFile("/tmp/division_table.pdf")
+	err = c.WriteToFile(tempFile("division_table.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}

--- a/pdf/creator/filled_curve_test.go
+++ b/pdf/creator/filled_curve_test.go
@@ -39,7 +39,7 @@ func TestNewFilledCurve(t *testing.T) {
 	creator.NewPage()
 	creator.Draw(filledCurve)
 
-	err := creator.WriteToFile("/tmp/filledCurve.pdf")
+	err := creator.WriteToFile(tempFile("filledCurve.pdf"))
 	if err != nil {
 		t.Errorf("Fail: %v", err)
 		return

--- a/pdf/creator/invoice_test.go
+++ b/pdf/creator/invoice_test.go
@@ -74,7 +74,7 @@ func TestInvoiceSimple(t *testing.T) {
 	}
 
 	// Write output file.
-	err = c.WriteToFile("/tmp/invoice_simple.pdf")
+	err = c.WriteToFile(tempFile("invoice_simple.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}
@@ -220,7 +220,7 @@ func TestInvoiceAdvanced(t *testing.T) {
 	}
 
 	// Write output file.
-	err = c.WriteToFile("/tmp/invoice_advanced.pdf")
+	err = c.WriteToFile(tempFile("invoice_advanced.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}

--- a/pdf/creator/styled_paragraph_test.go
+++ b/pdf/creator/styled_paragraph_test.go
@@ -270,7 +270,7 @@ func TestParagraphRegularVsStyled(t *testing.T) {
 	}
 
 	// Write output file.
-	err = c.WriteToFile("/tmp/paragraphs_regular_vs_styled.pdf")
+	err = c.WriteToFile(tempFile("paragraphs_regular_vs_styled.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}
@@ -363,7 +363,7 @@ func TestStyledParagraph(t *testing.T) {
 	}
 
 	// Write output file.
-	err = c.WriteToFile("/tmp/styled_paragraph.pdf")
+	err = c.WriteToFile(tempFile("styled_paragraph.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}

--- a/pdf/creator/table_test.go
+++ b/pdf/creator/table_test.go
@@ -50,7 +50,7 @@ func TestTableMultiParagraphWrapped(t *testing.T) {
 		t.Fatalf("Error drawing: %v", err)
 	}
 
-	err = c.WriteToFile("/tmp/table_pagehist.pdf")
+	err = c.WriteToFile(tempFile("table_pagehist.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}
@@ -115,7 +115,7 @@ func TestTableWithImage(t *testing.T) {
 		t.Fatalf("Error drawing: %v", err)
 	}
 
-	err = c.WriteToFile("/tmp/table_pagehist_with_img.pdf")
+	err = c.WriteToFile(tempFile("table_pagehist_with_img.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}
@@ -225,7 +225,7 @@ func TestTableWithDiv(t *testing.T) {
 		t.Fatalf("Error drawing: %v", err)
 	}
 
-	err = c.WriteToFile("/tmp/table_pagehist_with_div.pdf")
+	err = c.WriteToFile(tempFile("table_pagehist_with_div.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}

--- a/pdf/creator/toc_test.go
+++ b/pdf/creator/toc_test.go
@@ -102,7 +102,7 @@ func TestTOCAdvanced(t *testing.T) {
 	}
 
 	// Write output file.
-	err = c.WriteToFile("/tmp/toc_advanced.pdf")
+	err = c.WriteToFile(tempFile("toc_advanced.pdf"))
 	if err != nil {
 		t.Fatalf("Fail: %v\n", err)
 	}


### PR DESCRIPTION
Output generated pdfs should always be to a temporary directory via os.TempDir() which allows customization and works on all OS rather than /tmp.