### PR TITLE
Read TTF font data once

### DIFF
--- a/pdf/model/font_composite.go
+++ b/pdf/model/font_composite.go
@@ -6,6 +6,7 @@
 package model
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -468,7 +469,12 @@ func newPdfCIDFontType2FromPdfObject(d *core.PdfObjectDictionary, base *fontComm
 // TODO: May be extended in the future to support a larger variety of CMaps and vertical fonts.
 func NewCompositePdfFontFromTTFFile(filePath string) (*PdfFont, error) {
 	// Load the truetype font data.
-	ttf, err := fonts.TtfParse(filePath)
+	ttfBytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		common.Log.Debug("ERROR: while reading ttf font: %v", err)
+		return nil, err
+	}
+	ttf, err := fonts.TtfParse(bytes.NewReader(ttfBytes))
 	if err != nil {
 		common.Log.Debug("ERROR: while loading ttf font: %v", err)
 		return nil, err
@@ -543,12 +549,6 @@ func NewCompositePdfFontFromTTFFile(filePath string) (*PdfFont, error) {
 	}
 
 	// Embed the TrueType font program.
-	ttfBytes, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		common.Log.Debug("ERROR: Unable to read file contents: %v", err)
-		return nil, err
-	}
-
 	stream, err := core.MakeStream(ttfBytes, core.NewFlateEncoder())
 	if err != nil {
 		common.Log.Debug("ERROR: Unable to make stream: %v", err)

--- a/pdf/model/font_simple.go
+++ b/pdf/model/font_simple.go
@@ -395,7 +395,7 @@ func NewPdfFontFromTTFFile(filePath string) (*PdfFont, error) {
 	const minCode = textencoding.CharCode(32)
 	const maxCode = textencoding.CharCode(255)
 
-	ttf, err := fonts.TtfParse(filePath)
+	ttf, err := fonts.TtfParseFile(filePath)
 	if err != nil {
 		common.Log.Debug("ERROR: loading ttf font: %v", err)
 		return nil, err

--- a/pdf/model/fonts/ttfparser.go
+++ b/pdf/model/fonts/ttfparser.go
@@ -170,15 +170,20 @@ func NewFontFile2FromPdfObject(obj core.PdfObject) (TtfType, error) {
 	return t.Parse()
 }
 
-// TtfParse returns a TtfType describing the TrueType font file in disk file `fileStr`.
-func TtfParse(fileStr string) (TtfType, error) {
+// TtfParseFile returns a TtfType describing the TrueType font file in disk file `fileStr`.
+func TtfParseFile(fileStr string) (TtfType, error) {
 	f, err := os.Open(fileStr)
 	if err != nil {
 		return TtfType{}, err
 	}
 	defer f.Close()
 
-	t := ttfParser{f: f}
+	return TtfParse(f)
+}
+
+// TtfParse returns a TtfType describing the TrueType font.
+func TtfParse(r io.ReadSeeker) (TtfType, error) {
+	t := &ttfParser{f: r}
 	return t.Parse()
 }
 

--- a/pdf/model/fonts/ttfparser_test.go
+++ b/pdf/model/fonts/ttfparser_test.go
@@ -80,7 +80,7 @@ func TestTTFParse(t *testing.T) {
 		t.Run(c.path, func(t *testing.T) {
 			path := filepath.Join(fontDir, c.path)
 
-			ft, err := TtfParse(path)
+			ft, err := TtfParseFile(path)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Currently, the code reads TTF file twice: once to parse it and the second time to embed it into the PDF. This PR changes it to read the file once and reuse the data to parse and embed the font.