### PR TITLE
Multipage table fix

### DIFF
--- a/pdf/creator/invoice_test.go
+++ b/pdf/creator/invoice_test.go
@@ -51,7 +51,7 @@ func TestInvoiceSimple(t *testing.T) {
 	})
 
 	// Add invoice line items.
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 75; i++ {
 		invoice.AddLine(
 			fmt.Sprintf("Test product #%d", i+1),
 			"1",

--- a/pdf/creator/table.go
+++ b/pdf/creator/table.go
@@ -331,7 +331,9 @@ func (table *Table) GeneratePageBlocks(ctx DrawContext) ([]*Block, DrawContext, 
 			block = NewBlock(ctx.PageWidth, ctx.PageHeight)
 			ulX = ctx.Margins.left
 			ulY = ctx.Margins.top
+
 			ctx.Height = ctx.PageHeight - ctx.Margins.top - ctx.Margins.bottom
+			origHeight = ctx.Height
 
 			startrow = cell.row - 1
 			yrel = 0


### PR DESCRIPTION
Resolves #299

The issue this pull request fixes can be easily reproduced by having a table spanning multiple pages that does not start at the top of the page it's currently drawn on (it has some other components above it on that page). 

In this scenario, the total height of new pages is based on the height of the page the table starts on (which is not a complete page)