### PR TITLE
Fix integer overflow on 32-bit machines

### DIFF
--- a/pdf/core/crypt.go
+++ b/pdf/core/crypt.go
@@ -37,7 +37,7 @@ type PdfCrypt struct {
 	U                []byte
 	OE               []byte // R=6
 	UE               []byte // R=6
-	P                int    // TODO (v3): uint32
+	P                int64  // TODO (v3): uint32
 	Perms            []byte // R=6
 	EncryptMetadata  bool
 	Id0              string
@@ -421,7 +421,7 @@ func PdfCryptMakeNew(parser *PdfParser, ed, trailer *PdfObjectDictionary) (PdfCr
 	if !ok {
 		return crypter, errors.New("Encrypt dictionary missing permissions attr")
 	}
-	crypter.P = int(*P)
+	crypter.P = int64(*P)
 
 	if crypter.R == 6 {
 		Perms, ok := ed.Get("Perms").(*PdfObjectString)
@@ -1718,7 +1718,7 @@ func (crypt *PdfCrypt) alg13(fkey []byte) (bool, error) {
 	if !bytes.Equal(perms[9:12], []byte("adb")) {
 		return false, errors.New("decoded permissions are invalid")
 	}
-	p := int(int32(binary.LittleEndian.Uint32(perms[0:4])))
+	p := int64(int32(binary.LittleEndian.Uint32(perms[0:4])))
 	if p != crypt.P {
 		return false, errors.New("permissions validation failed")
 	}

--- a/pdf/model/writer.go
+++ b/pdf/model/writer.go
@@ -538,7 +538,7 @@ func (this *PdfWriter) Encrypt(userPass, ownerPass []byte, options *EncryptOptio
 	crypter.P = math.MaxUint32
 	crypter.EncryptMetadata = true
 	if options != nil {
-		crypter.P = int(options.Permissions.GetP())
+		crypter.P = int64(options.Permissions.GetP())
 	}
 
 	// Generate the encryption dictionary.


### PR DESCRIPTION
As reported by https://github.com/unidoc/unidoc/issues/324 Unidoc build fails on 32-bit architectures.

The upcoming v3 version already contains the fix, so this change only works around an issue for the current version.

The reason for an overflow is that `P` (permissions) field is defined as `int`, while it should really be `uint32`. One of the operations sets all permissions by assigning `MaxUint32`. This works on 64-bit, but fails on 32-bit because the maximal integer is positive, while to represent the same value it's required to use `int(-1)` expression.

The only solution right now is to redefine the field to be `int64` instead of int.
It's not possible to change it to `uint32` because it might cause breakage for existing users.