### PR TITLE
Define PDF font interface

### DIFF
--- a/pdf/annotator/field_appearance.go
+++ b/pdf/annotator/field_appearance.go
@@ -212,7 +212,7 @@ func genFieldTextAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFieldT
 	// Add DA operands.
 	var fontsize float64
 	var fontname *core.PdfObjectName
-	var font *model.PdfFont
+	var font model.PdfFont
 	autosize := true
 
 	fontsizeDef := height * style.AutoFontSizeFraction
@@ -529,7 +529,7 @@ func genFieldTextCombAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFi
 	// Add DA operands.
 	var fontsize float64
 	var fontname *core.PdfObjectName
-	var font *model.PdfFont
+	var font model.PdfFont
 	autosize := true
 
 	fontsizeDef := height * style.AutoFontSizeFraction
@@ -901,7 +901,7 @@ func makeComboboxTextXObjForm(width, height float64, text string, style Appearan
 	// Add DA operands.
 	var fontsize float64
 	var fontname *core.PdfObjectName
-	var font *model.PdfFont
+	var font model.PdfFont
 	var err error
 	autosize := true
 
@@ -1065,7 +1065,7 @@ func drawAlignmentReticle(cc *contentstream.ContentCreator, style AppearanceStyl
 
 // Apply appearance characteristics from an MK dictionary `mkDict` to appearance `style`.
 // `font` is necessary when the "normal caption" (CA) field is specified (checkboxes).
-func (style *AppearanceStyle) applyAppearanceCharacteristics(mkDict *core.PdfObjectDictionary, bsDict *core.PdfObjectDictionary, font *model.PdfFont) error {
+func (style *AppearanceStyle) applyAppearanceCharacteristics(mkDict *core.PdfObjectDictionary, bsDict *core.PdfObjectDictionary, font model.PdfFont) error {
 	if !style.AllowMK {
 		return nil
 	}

--- a/pdf/annotator/field_appearance.go
+++ b/pdf/annotator/field_appearance.go
@@ -265,10 +265,7 @@ func genFieldTextAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFieldT
 		resources.SetFontByName(*fontname, fontobj)
 	}
 	encoder := font.Encoder()
-	fdescriptor, err := font.GetFontDescriptor()
-	if err != nil {
-		common.Log.Debug("Error: Unable to get font descriptor")
-	}
+	fdescriptor := font.GetFontDescriptor()
 
 	var text string
 	if str, ok := core.GetString(ftxt.V); ok {
@@ -618,10 +615,8 @@ func genFieldTextCombAppearance(wa *model.PdfAnnotationWidget, ftxt *model.PdfFi
 		maxGlyphWy = 1000
 	}
 
-	fdescriptor, err := font.GetFontDescriptor()
-	if err != nil {
-		common.Log.Debug("Error: Unable to get font descriptor")
-	}
+	fdescriptor := font.GetFontDescriptor()
+
 	var fcapheight float64
 	if fdescriptor != nil {
 		fcapheight, err = fdescriptor.GetCapHeight()

--- a/pdf/creator/creator.go
+++ b/pdf/creator/creator.go
@@ -61,8 +61,8 @@ type Creator struct {
 	optimizer model.Optimizer
 
 	// Default fonts used by all components instantiated through the creator.
-	defaultFontRegular *model.PdfFont
-	defaultFontBold    *model.PdfFont
+	defaultFontRegular model.PdfFont
+	defaultFontBold    model.PdfFont
 }
 
 // SetForms adds an Acroform to a PDF file.  Sets the specified form for writing.

--- a/pdf/creator/creator_test.go
+++ b/pdf/creator/creator_test.go
@@ -499,7 +499,7 @@ func TestParagraphFonts(t *testing.T) {
 
 	helvetica := model.NewStandard14FontMustCompile(fonts.HelveticaName)
 
-	fonts := []*model.PdfFont{roboto, robotoBold, helvetica, roboto, robotoBold, helvetica}
+	fonts := []model.PdfFont{roboto, robotoBold, helvetica, roboto, robotoBold, helvetica}
 	for _, font := range fonts {
 		p := creator.NewParagraph("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt" +
 			"ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut " +
@@ -1172,7 +1172,7 @@ func TestBorderedTable2(t *testing.T) {
 	testWriteAndRender(t, c, "4_table_bordered2.pdf")
 }
 
-func newContent(c *Creator, text string, alignment TextAlignment, font *model.PdfFont, fontSize float64, color Color) *Paragraph {
+func newContent(c *Creator, text string, alignment TextAlignment, font model.PdfFont, fontSize float64, color Color) *Paragraph {
 	p := c.NewParagraph(text)
 	p.SetFontSize(fontSize)
 	p.SetTextAlignment(alignment)

--- a/pdf/creator/division_test.go
+++ b/pdf/creator/division_test.go
@@ -27,7 +27,7 @@ func RandString(length int) string {
 	return string(b)
 }
 
-func newStandard14Font(t testing.TB, base fonts.StdFontName) *model.PdfFont {
+func newStandard14Font(t testing.TB, base fonts.StdFontName) model.PdfFont {
 	f, err := model.NewStandard14Font(base)
 	if err != nil {
 		t.Fatalf("Error opening font: %v", err)

--- a/pdf/creator/paragraph.go
+++ b/pdf/creator/paragraph.go
@@ -23,7 +23,7 @@ type Paragraph struct {
 	text string
 
 	// The font to be used to draw the text.
-	textFont *model.PdfFont
+	textFont model.PdfFont
 
 	// The font size (points).
 	fontSize float64
@@ -102,7 +102,7 @@ func newParagraph(text string, style TextStyle) *Paragraph {
 }
 
 // SetFont sets the Paragraph's font.
-func (p *Paragraph) SetFont(font *model.PdfFont) {
+func (p *Paragraph) SetFont(font model.PdfFont) {
 	p.textFont = font
 }
 

--- a/pdf/creator/paragraph.go
+++ b/pdf/creator/paragraph.go
@@ -293,7 +293,7 @@ func (p *Paragraph) wrapText() error {
 		metrics, found := p.textFont.GetRuneMetrics(r)
 		if !found {
 			common.Log.Debug("ERROR: Rune char metrics not found! rune=0x%04x=%c font=%s %#q",
-				r, r, p.textFont.BaseFont(), p.textFont.Subtype())
+				r, r, p.textFont.BaseFont(), p.textFont.FullSubtype())
 			common.Log.Trace("Font: %#v", p.textFont)
 			common.Log.Trace("Encoder: %#v", p.textFont.Encoder())
 			return errors.New("glyph char metrics missing")
@@ -468,7 +468,7 @@ func drawParagraphOnBlock(blk *Block, p *Paragraph, ctx DrawContext) (DrawContex
 			if !found {
 				common.Log.Debug("Unsupported rune i=%d rune=0x%04x=%c in font %s %s",
 					i, r, r,
-					p.textFont.BaseFont(), p.textFont.Subtype())
+					p.textFont.BaseFont(), p.textFont.FullSubtype())
 				return ctx, errors.New("unsupported text glyph")
 			}
 

--- a/pdf/creator/text_style.go
+++ b/pdf/creator/text_style.go
@@ -15,14 +15,14 @@ type TextStyle struct {
 	Color Color
 
 	// The font the text will use.
-	Font *model.PdfFont
+	Font model.PdfFont
 
 	// The size of the font.
 	FontSize float64
 }
 
 // newTextStyle creates a new text style object using the specified font.
-func newTextStyle(font *model.PdfFont) TextStyle {
+func newTextStyle(font model.PdfFont) TextStyle {
 	return TextStyle{
 		Color:    ColorRGBFrom8bit(0, 0, 0),
 		Font:     font,
@@ -32,7 +32,7 @@ func newTextStyle(font *model.PdfFont) TextStyle {
 
 // newLinkStyle creates a new text style object which can be
 // used for link annotations.
-func newLinkStyle(font *model.PdfFont) TextStyle {
+func newLinkStyle(font model.PdfFont) TextStyle {
 	return TextStyle{
 		Color:    ColorRGBFrom8bit(0, 0, 238),
 		Font:     font,

--- a/pdf/extractor/text.go
+++ b/pdf/extractor/text.go
@@ -671,12 +671,12 @@ func (to *textObject) renderText(data []byte) error {
 	state := to.state
 	tfs := state.tfs
 	th := state.th / 100.0
-	spaceMetrics, ok := font.GetRuneCharMetrics(' ')
+	spaceMetrics, ok := font.GetRuneMetrics(' ')
 	if !ok {
 		spaceMetrics, ok = font.GetCharMetrics(32)
 	}
 	if !ok {
-		spaceMetrics, _ = model.DefaultFont().GetRuneCharMetrics(' ')
+		spaceMetrics, _ = model.DefaultFont().GetRuneMetrics(' ')
 	}
 	spaceWidth := spaceMetrics.Wx * glyphTextRatio
 	common.Log.Trace("spaceWidth=%.2f text=%q font=%s fontSize=%.1f", spaceWidth, runes, font, tfs)

--- a/pdf/extractor/text.go
+++ b/pdf/extractor/text.go
@@ -521,7 +521,7 @@ func (to *textObject) checkOp(op *contentstream.ContentStreamOperation, numParam
 }
 
 // fontStacker is the PDF font stack implementation.
-type fontStacker []*model.PdfFont
+type fontStacker []model.PdfFont
 
 // String returns a string describing the current state of the font stack.
 func (fontStack *fontStacker) String() string {
@@ -537,12 +537,12 @@ func (fontStack *fontStacker) String() string {
 }
 
 // push pushes `font` onto the font stack.
-func (fontStack *fontStacker) push(font *model.PdfFont) {
+func (fontStack *fontStacker) push(font model.PdfFont) {
 	*fontStack = append(*fontStack, font)
 }
 
 // pop pops and returns the element on the top of the font stack if there is one or nil if there isn't.
-func (fontStack *fontStacker) pop() *model.PdfFont {
+func (fontStack *fontStacker) pop() model.PdfFont {
 	if fontStack.empty() {
 		return nil
 	}
@@ -552,7 +552,7 @@ func (fontStack *fontStacker) pop() *model.PdfFont {
 }
 
 // peek returns the element on the top of the font stack if there is one or nil if there isn't.
-func (fontStack *fontStacker) peek() *model.PdfFont {
+func (fontStack *fontStacker) peek() model.PdfFont {
 	if fontStack.empty() {
 		return nil
 	}
@@ -563,7 +563,7 @@ func (fontStack *fontStacker) peek() *model.PdfFont {
 //  idx = 0: bottom of font stack
 //  idx = len(fontstack) - 1: top of font stack
 //  idx = -n is same as dx = len(fontstack) - n, so fontstack.get(-1) is same as fontstack.peek()
-func (fontStack *fontStacker) get(idx int) *model.PdfFont {
+func (fontStack *fontStacker) get(idx int) model.PdfFont {
 	if idx < 0 {
 		idx += fontStack.size()
 	}
@@ -590,14 +590,14 @@ func (fontStack *fontStacker) size() int {
 
 // textState represents the text state.
 type textState struct {
-	tc    float64        // Character spacing. Unscaled text space units.
-	tw    float64        // Word spacing. Unscaled text space units.
-	th    float64        // Horizontal scaling.
-	tl    float64        // Leading. Unscaled text space units. Used by TD,T*,'," see Table 108.
-	tfs   float64        // Text font size.
-	tmode RenderMode     // Text rendering mode.
-	trise float64        // Text rise. Unscaled text space units. Set by Ts.
-	tfont *model.PdfFont // Text font.
+	tc    float64       // Character spacing. Unscaled text space units.
+	tw    float64       // Word spacing. Unscaled text space units.
+	th    float64       // Horizontal scaling.
+	tl    float64       // Leading. Unscaled text space units. Used by TD,T*,'," see Table 108.
+	tfs   float64       // Text font size.
+	tmode RenderMode    // Text rendering mode.
+	trise float64       // Text rise. Unscaled text space units. Set by Ts.
+	tfont model.PdfFont // Text font.
 	// For debugging
 	numChars  int
 	numMisses int
@@ -1213,7 +1213,7 @@ var diacritics = map[rune]string{
 
 // getCurrentFont returns the font on top of the font stack, or DefaultFont if the font stack is
 // empty.
-func (to *textObject) getCurrentFont() *model.PdfFont {
+func (to *textObject) getCurrentFont() model.PdfFont {
 	if to.fontStack.empty() {
 		common.Log.Debug("ERROR: No font defined. Using default.")
 		return model.DefaultFont()
@@ -1223,7 +1223,7 @@ func (to *textObject) getCurrentFont() *model.PdfFont {
 
 // getFont returns the font named `name` if it exists in the page's resources or an error if it
 // doesn't. It caches the returned fonts.
-func (to *textObject) getFont(name string) (*model.PdfFont, error) {
+func (to *textObject) getFont(name string) (model.PdfFont, error) {
 	if to.e.fontCache != nil {
 		to.e.accessCount++
 		entry, ok := to.e.fontCache[name]
@@ -1261,8 +1261,8 @@ func (to *textObject) getFont(name string) (*model.PdfFont, error) {
 
 // fontEntry is a entry in the font cache.
 type fontEntry struct {
-	font   *model.PdfFont // The font being cached.
-	access int64          // Last access. Used to determine LRU cache victims.
+	font   model.PdfFont // The font being cached.
+	access int64         // Last access. Used to determine LRU cache victims.
 }
 
 // maxFontCache is the maximum number of PdfFont's in fontCache.
@@ -1270,7 +1270,7 @@ const maxFontCache = 10
 
 // getFontDirect returns the font named `name` if it exists in the page's resources or an error if
 // it doesn't. Accesses page resources directly (not cached).
-func (to *textObject) getFontDirect(name string) (*model.PdfFont, error) {
+func (to *textObject) getFontDirect(name string) (model.PdfFont, error) {
 	fontObj, err := to.getFontDict(name)
 	if err != nil {
 		return nil, err

--- a/pdf/extractor/text.go
+++ b/pdf/extractor/text.go
@@ -658,8 +658,8 @@ func (to *textObject) renderText(data []byte) error {
 
 	font := to.getCurrentFont()
 
+	// TODO(dennwc): this pair of calls should really be font.Encoder().Decode()
 	charcodes := font.BytesToCharcodes(data)
-
 	runes, numChars, numMisses := font.CharcodesToUnicodeWithStats(charcodes)
 	if numMisses > 0 {
 		common.Log.Debug("renderText: numChars=%d numMisses=%d", numChars, numMisses)
@@ -672,9 +672,6 @@ func (to *textObject) renderText(data []byte) error {
 	tfs := state.tfs
 	th := state.th / 100.0
 	spaceMetrics, ok := font.GetRuneMetrics(' ')
-	if !ok {
-		spaceMetrics, ok = font.GetCharMetrics(32)
-	}
 	if !ok {
 		spaceMetrics, _ = model.DefaultFont().GetRuneMetrics(' ')
 	}
@@ -708,9 +705,9 @@ func (to *textObject) renderText(data []byte) error {
 			w = state.tw
 		}
 
-		m, ok := font.GetCharMetrics(code)
+		m, ok := font.GetRuneMetrics(r)
 		if !ok {
-			common.Log.Debug("ERROR: No metric for code=%d r=0x%04x=%+q %s", code, r, r, font)
+			common.Log.Debug("ERROR: No metric for r=0x%04x=%+q %s", r, r, font)
 			return errors.New("no char metrics")
 		}
 

--- a/pdf/model/font.go
+++ b/pdf/model/font.go
@@ -41,23 +41,6 @@ type PdfFont interface {
 	ToUnicode() core.PdfObject
 	ToUnicodeCMap() *cmap.CMap
 
-	// GetCharMetrics returns the char metrics for character code `code`.
-	// How it works:
-	//  1) It calls the GetCharMetrics function for the underlying font, either a simple font or
-	//     a Type0 font. The underlying font GetCharMetrics() functions do direct charcode ➞  metrics
-	//     mappings.
-	//  2) If the underlying font's GetCharMetrics() doesn't have a CharMetrics for `code` then a
-	//     a CharMetrics with the FontDescriptor's /MissingWidth is returned.
-	//  3) If there is no /MissingWidth then a failure is returned.
-	// TODO(peterwilliams97) There is nothing callers can do if no CharMetrics are found so we might as
-	//                       well give them 0 width. There is no need for the bool return.
-	// TODO(gunnsth): Reconsider whether needed or if can map via GlyphName.
-	// TODO(peterwilliams97): pdfFontType0.GetCharMetrics() calls pdfCIDFontType2.GetCharMetrics()
-	// 						  through this function. Would it be more straightforward for
-	// 						  pdfFontType0.GetCharMetrics() to call pdfCIDFontType0.GetCharMetrics()
-	// 						  and pdfCIDFontType2.GetCharMetrics() directly?
-	GetCharMetrics(code textencoding.CharCode) (fonts.CharMetrics, bool)
-
 	// BytesToCharcodes converts the bytes in a PDF string to character codes.
 	// TODO(dennwc): Shouldn't this be done by the encoder?
 	BytesToCharcodes(data []byte) []textencoding.CharCode

--- a/pdf/model/font.go
+++ b/pdf/model/font.go
@@ -364,21 +364,6 @@ func (font *PdfFont) CharcodesToUnicodeWithStats(charcodes []textencoding.CharCo
 	return runes, len(runes), numMisses
 }
 
-// GetRuneMetrics returns the char metrics for a rune.
-// TODO(peterwilliams97) There is nothing callers can do if no CharMetrics are found so we might as
-//                       well give them 0 width. There is no need for the bool return.
-func (font *PdfFont) GetRuneMetrics(r rune) (fonts.CharMetrics, bool) {
-	if m, ok := font.PdfFontSub.GetRuneMetrics(r); ok {
-		return m, true
-	}
-	if desc := font.GetFontDescriptor(); desc != nil {
-		return fonts.CharMetrics{Wx: desc.missingWidth}, true
-	}
-
-	common.Log.Debug("GetGlyphCharMetrics: No metrics for font=%s", font)
-	return fonts.CharMetrics{}, false
-}
-
 // GetCharMetrics returns the char metrics for character code `code`.
 // How it works:
 //  1) It calls the GetCharMetrics function for the underlying font, either a simple font or
@@ -408,28 +393,6 @@ func (font *PdfFont) GetCharMetrics(code textencoding.CharCode) (fonts.CharMetri
 
 	common.Log.Debug("GetCharMetrics: No metrics for font=%s", font)
 	return fonts.CharMetrics{}, false
-}
-
-// GetRuneCharMetrics returns the char metrics for rune `r`.
-// TODO(peterwilliams97) There is nothing callers can do if no CharMetrics are found so we might as
-//                       well give them 0 width. There is no need for the bool return.
-func (font *PdfFont) GetRuneCharMetrics(r rune) (fonts.CharMetrics, bool) {
-	var nometrics fonts.CharMetrics
-
-	encoder := font.Encoder()
-	if encoder != nil {
-		m, ok := font.GetRuneMetrics(r)
-		if ok {
-			return m, true
-		}
-		common.Log.Debug("ERROR: Metrics not found for rune=%+v %s", r, font)
-	}
-	if desc := font.GetFontDescriptor(); desc != nil {
-		return fonts.CharMetrics{Wx: desc.missingWidth}, true
-	}
-
-	common.Log.Debug("GetRuneCharMetrics: No metrics for font=%s", font)
-	return nometrics, false
 }
 
 // fontCommon represents the fields that are common to all PDF fonts.

--- a/pdf/model/font_composite.go
+++ b/pdf/model/font_composite.go
@@ -12,6 +12,8 @@ import (
 	"io/ioutil"
 	"sort"
 
+	"github.com/unidoc/unidoc/pdf/internal/cmap"
+
 	"github.com/unidoc/unidoc/common"
 	"github.com/unidoc/unidoc/pdf/core"
 	"github.com/unidoc/unidoc/pdf/internal/textencoding"
@@ -112,13 +114,28 @@ func pdfFontType0FromSkeleton(base *fontCommon) *pdfFontType0 {
 	}
 }
 
-// baseFields returns the fields of `font` that are common to all PDF fonts.
-func (font *pdfFontType0) baseFields() *fontCommon {
-	return &font.fontCommon
+func (font *pdfFontType0) BaseFont() string {
+	return font.basefont
 }
 
-func (font *pdfFontType0) getFontDescriptor() *PdfFontDescriptor {
+func (font *pdfFontType0) Subtype() string {
+	return font.subtype
+}
+
+func (font *pdfFontType0) ToUnicode() core.PdfObject {
+	return font.toUnicode
+}
+
+func (font *pdfFontType0) ToUnicodeCMap() *cmap.CMap {
+	return font.toUnicodeCmap
+}
+
+func (font *pdfFontType0) GetFontDescriptor() *PdfFontDescriptor {
 	return font.fontDescriptor
+}
+
+func (font *pdfFontType0) BuiltinDescriptor() bool {
+	return false
 }
 
 // GetRuneMetrics returns the character metrics for the specified rune.
@@ -150,7 +167,7 @@ func (font *pdfFontType0) ToPdfObject() core.PdfObject {
 	if font.container == nil {
 		font.container = &core.PdfIndirectObject{}
 	}
-	d := font.baseFields().asPdfObjectDictionary("Type0")
+	d := asPdfObjectDictionary(font, "Type0")
 
 	font.container.PdfObject = d
 
@@ -225,13 +242,28 @@ func pdfCIDFontType0FromSkeleton(base *fontCommon) *pdfCIDFontType0 {
 	}
 }
 
-// baseFields returns the fields of `font` that are common to all PDF fonts.
-func (font *pdfCIDFontType0) baseFields() *fontCommon {
-	return &font.fontCommon
+func (font *pdfCIDFontType0) BaseFont() string {
+	return font.basefont
 }
 
-func (font *pdfCIDFontType0) getFontDescriptor() *PdfFontDescriptor {
+func (font *pdfCIDFontType0) Subtype() string {
+	return font.subtype
+}
+
+func (font *pdfCIDFontType0) ToUnicode() core.PdfObject {
+	return font.toUnicode
+}
+
+func (font *pdfCIDFontType0) ToUnicodeCMap() *cmap.CMap {
+	return font.toUnicodeCmap
+}
+
+func (font *pdfCIDFontType0) GetFontDescriptor() *PdfFontDescriptor {
 	return font.fontDescriptor
+}
+
+func (font *pdfCIDFontType0) BuiltinDescriptor() bool {
+	return false
 }
 
 // Encoder returns the font's text encoder.
@@ -310,13 +342,28 @@ func pdfCIDFontType2FromSkeleton(base *fontCommon) *pdfCIDFontType2 {
 	}
 }
 
-// baseFields returns the fields of `font` that are common to all PDF fonts.
-func (font *pdfCIDFontType2) baseFields() *fontCommon {
-	return &font.fontCommon
+func (font *pdfCIDFontType2) BaseFont() string {
+	return font.basefont
 }
 
-func (font *pdfCIDFontType2) getFontDescriptor() *PdfFontDescriptor {
+func (font *pdfCIDFontType2) Subtype() string {
+	return font.subtype
+}
+
+func (font *pdfCIDFontType2) ToUnicode() core.PdfObject {
+	return font.toUnicode
+}
+
+func (font *pdfCIDFontType2) ToUnicodeCMap() *cmap.CMap {
+	return font.toUnicodeCmap
+}
+
+func (font *pdfCIDFontType2) GetFontDescriptor() *PdfFontDescriptor {
 	return font.fontDescriptor
+}
+
+func (font *pdfCIDFontType2) BuiltinDescriptor() bool {
+	return false
 }
 
 // Encoder returns the font's text encoder.
@@ -358,7 +405,7 @@ func (font *pdfCIDFontType2) ToPdfObject() core.PdfObject {
 	if font.container == nil {
 		font.container = &core.PdfIndirectObject{}
 	}
-	d := font.baseFields().asPdfObjectDictionary("CIDFontType2")
+	d := asPdfObjectDictionary(font, "CIDFontType2")
 	font.container.PdfObject = d
 
 	if font.CIDSystemInfo != nil {

--- a/pdf/model/font_composite.go
+++ b/pdf/model/font_composite.go
@@ -120,12 +120,16 @@ func pdfFontType0FromSkeleton(base *fontCommon) *pdfFontType0 {
 	}
 }
 
-func (font *pdfFontType0) BaseFont() string {
-	return font.basefont
+func (*pdfFontType0) IsCID() bool {
+	return true
 }
 
-func (font *pdfFontType0) Subtype() string {
-	return font.subtype
+func (*pdfFontType0) Subtype() string {
+	return "Type0"
+}
+
+func (font *pdfFontType0) BaseFont() string {
+	return font.basefont
 }
 
 func (font *pdfFontType0) FullSubtype() string {
@@ -149,8 +153,7 @@ func (font *pdfFontType0) BuiltinDescriptor() bool {
 }
 
 func (font *pdfFontType0) BytesToCharcodes(data []byte) []textencoding.CharCode {
-	// TODO(dennwc): resolve branches and inline
-	return bytesToCharcodes(font, data)
+	return bytesToCharcodesCID(data)
 }
 
 func (font *pdfFontType0) CharcodeBytesToUnicode(data []byte) (string, int, int) {
@@ -276,12 +279,16 @@ func pdfCIDFontType0FromSkeleton(base *fontCommon) *pdfCIDFontType0 {
 
 func (*pdfCIDFontType0) isCID() {}
 
-func (font *pdfCIDFontType0) BaseFont() string {
-	return font.basefont
+func (*pdfCIDFontType0) IsCID() bool {
+	return true
 }
 
-func (font *pdfCIDFontType0) Subtype() string {
-	return font.subtype
+func (*pdfCIDFontType0) Subtype() string {
+	return "CIDFontType0"
+}
+
+func (font *pdfCIDFontType0) BaseFont() string {
+	return font.basefont
 }
 
 func (font *pdfCIDFontType0) FullSubtype() string {
@@ -310,8 +317,7 @@ func (font pdfCIDFontType0) Encoder() textencoding.TextEncoder {
 }
 
 func (font *pdfCIDFontType0) BytesToCharcodes(data []byte) []textencoding.CharCode {
-	// TODO(dennwc): resolve branches and inline
-	return bytesToCharcodes(font, data)
+	return bytesToCharcodesCID(data)
 }
 
 func (font *pdfCIDFontType0) CharcodeBytesToUnicode(data []byte) (string, int, int) {
@@ -405,12 +411,16 @@ func pdfCIDFontType2FromSkeleton(base *fontCommon) *pdfCIDFontType2 {
 
 func (*pdfCIDFontType2) isCID() {}
 
-func (font *pdfCIDFontType2) BaseFont() string {
-	return font.basefont
+func (*pdfCIDFontType2) IsCID() bool {
+	return true
 }
 
-func (font *pdfCIDFontType2) Subtype() string {
-	return font.subtype
+func (*pdfCIDFontType2) Subtype() string {
+	return "CIDFontType2"
+}
+
+func (font *pdfCIDFontType2) BaseFont() string {
+	return font.basefont
 }
 
 func (font *pdfCIDFontType2) FullSubtype() string {
@@ -434,8 +444,7 @@ func (font *pdfCIDFontType2) BuiltinDescriptor() bool {
 }
 
 func (font *pdfCIDFontType2) BytesToCharcodes(data []byte) []textencoding.CharCode {
-	// TODO(dennwc): resolve branches and inline
-	return bytesToCharcodes(font, data)
+	return bytesToCharcodesCID(data)
 }
 
 func (font *pdfCIDFontType2) CharcodeBytesToUnicode(data []byte) (string, int, int) {

--- a/pdf/model/font_composite.go
+++ b/pdf/model/font_composite.go
@@ -143,6 +143,21 @@ func (font *pdfFontType0) BuiltinDescriptor() bool {
 	return false
 }
 
+func (font *pdfFontType0) BytesToCharcodes(data []byte) []textencoding.CharCode {
+	// TODO(dennwc): resolve branches and inline
+	return bytesToCharcodes(font, data)
+}
+
+func (font *pdfFontType0) CharcodeBytesToUnicode(data []byte) (string, int, int) {
+	// TODO(dennwc): resolve branches and inline
+	return charcodeBytesToUnicode(font, data)
+}
+
+func (font *pdfFontType0) CharcodesToUnicodeWithStats(charcodes []textencoding.CharCode) (runelist []rune, numHits, numMisses int) {
+	// TODO(dennwc): resolve branches and inline
+	return charcodesToUnicodeWithStats(font, charcodes)
+}
+
 // GetRuneMetrics returns the character metrics for the specified rune.
 // A bool flag is returned to indicate whether or not the entry was found.
 func (font pdfFontType0) GetRuneMetrics(r rune) (fonts.CharMetrics, bool) {
@@ -280,6 +295,21 @@ func (font pdfCIDFontType0) Encoder() textencoding.TextEncoder {
 	return font.encoder
 }
 
+func (font *pdfCIDFontType0) BytesToCharcodes(data []byte) []textencoding.CharCode {
+	// TODO(dennwc): resolve branches and inline
+	return bytesToCharcodes(font, data)
+}
+
+func (font *pdfCIDFontType0) CharcodeBytesToUnicode(data []byte) (string, int, int) {
+	// TODO(dennwc): resolve branches and inline
+	return charcodeBytesToUnicode(font, data)
+}
+
+func (font *pdfCIDFontType0) CharcodesToUnicodeWithStats(charcodes []textencoding.CharCode) (runelist []rune, numHits, numMisses int) {
+	// TODO(dennwc): resolve branches and inline
+	return charcodesToUnicodeWithStats(font, charcodes)
+}
+
 // GetRuneMetrics returns the character metrics for the specified rune.
 // A bool flag is returned to indicate whether or not the entry was found.
 func (font pdfCIDFontType0) GetRuneMetrics(r rune) (fonts.CharMetrics, bool) {
@@ -381,6 +411,21 @@ func (font *pdfCIDFontType2) GetFontDescriptor() *PdfFontDescriptor {
 
 func (font *pdfCIDFontType2) BuiltinDescriptor() bool {
 	return false
+}
+
+func (font *pdfCIDFontType2) BytesToCharcodes(data []byte) []textencoding.CharCode {
+	// TODO(dennwc): resolve branches and inline
+	return bytesToCharcodes(font, data)
+}
+
+func (font *pdfCIDFontType2) CharcodeBytesToUnicode(data []byte) (string, int, int) {
+	// TODO(dennwc): resolve branches and inline
+	return charcodeBytesToUnicode(font, data)
+}
+
+func (font *pdfCIDFontType2) CharcodesToUnicodeWithStats(charcodes []textencoding.CharCode) (runelist []rune, numHits, numMisses int) {
+	// TODO(dennwc): resolve branches and inline
+	return charcodesToUnicodeWithStats(font, charcodes)
 }
 
 // Encoder returns the font's text encoder.

--- a/pdf/model/font_composite.go
+++ b/pdf/model/font_composite.go
@@ -283,6 +283,10 @@ func (font pdfCIDFontType0) Encoder() textencoding.TextEncoder {
 // GetRuneMetrics returns the character metrics for the specified rune.
 // A bool flag is returned to indicate whether or not the entry was found.
 func (font pdfCIDFontType0) GetRuneMetrics(r rune) (fonts.CharMetrics, bool) {
+	// TODO(dennwc): shouldn't this return at least something?
+	if d := font.fontDescriptor; d != nil {
+		return fonts.CharMetrics{Wx: d.missingWidth}, true
+	}
 	return fonts.CharMetrics{}, true
 }
 
@@ -388,14 +392,17 @@ func (font pdfCIDFontType2) Encoder() textencoding.TextEncoder {
 // A bool flag is returned to indicate whether or not the entry was found.
 func (font pdfCIDFontType2) GetRuneMetrics(r rune) (fonts.CharMetrics, bool) {
 	w, found := font.runeToWidthMap[r]
-	if !found {
-		dw, ok := core.GetInt(font.DW)
-		if !ok {
-			return fonts.CharMetrics{}, false
-		}
-		w = int(*dw)
+	if found {
+		return fonts.CharMetrics{Wx: float64(w)}, true
 	}
-	return fonts.CharMetrics{Wx: float64(w)}, true
+	dw, found := core.GetInt(font.DW)
+	if found {
+		return fonts.CharMetrics{Wx: float64(*dw)}, true
+	}
+	if d := font.fontDescriptor; d != nil {
+		return fonts.CharMetrics{Wx: d.missingWidth}, true
+	}
+	return fonts.CharMetrics{}, false
 }
 
 // GetCharMetrics returns the char metrics for character code `code`.

--- a/pdf/model/font_composite.go
+++ b/pdf/model/font_composite.go
@@ -322,6 +322,10 @@ func (font pdfCIDFontType0) GetRuneMetrics(r rune) (fonts.CharMetrics, bool) {
 
 // GetCharMetrics returns the char metrics for character code `code`.
 func (font pdfCIDFontType0) GetCharMetrics(code textencoding.CharCode) (fonts.CharMetrics, bool) {
+	// TODO(dennwc): shouldn't this return at least something?
+	if d := font.fontDescriptor; d != nil {
+		return fonts.CharMetrics{Wx: d.missingWidth}, true
+	}
 	return fonts.CharMetrics{}, true
 }
 
@@ -461,6 +465,11 @@ func (font pdfCIDFontType2) GetCharMetrics(code textencoding.CharCode) (fonts.Ch
 	w, ok := font.runeToWidthMap[r]
 	if !ok {
 		w = int(font.defaultWidth)
+		if w == 0 {
+			if d := font.fontDescriptor; d != nil {
+				return fonts.CharMetrics{Wx: d.missingWidth}, true
+			}
+		}
 	}
 	return fonts.CharMetrics{Wx: float64(w)}, true
 }

--- a/pdf/model/font_simple.go
+++ b/pdf/model/font_simple.go
@@ -17,8 +17,8 @@ import (
 	"github.com/unidoc/unidoc/pdf/model/fonts"
 )
 
-// pdfFontSimple implements pdfFont
-var _ pdfFont = (*pdfFontSimple)(nil)
+// pdfFontSimple implements PdfFontSub
+var _ PdfFontSub = (*pdfFontSimple)(nil)
 
 // pdfFontSimple describes a Simple Font
 //
@@ -75,6 +75,10 @@ func (font *pdfFontSimple) BaseFont() string {
 }
 
 func (font *pdfFontSimple) Subtype() string {
+	return font.subtype
+}
+
+func (font *pdfFontSimple) FullSubtype() string {
 	return font.subtype
 }
 
@@ -506,11 +510,7 @@ func NewPdfFontFromTTFFile(filePath string) (*PdfFont, error) {
 	// Build Font.
 	truefont.fontDescriptor = descriptor
 
-	font := &PdfFont{
-		context: truefont,
-	}
-
-	return font, nil
+	return &PdfFont{truefont}, nil
 }
 
 // updateStandard14Font fills the font.charWidths for standard 14 fonts.

--- a/pdf/model/font_simple.go
+++ b/pdf/model/font_simple.go
@@ -17,8 +17,8 @@ import (
 	"github.com/unidoc/unidoc/pdf/model/fonts"
 )
 
-// pdfFontSimple implements PdfFontSub
-var _ PdfFontSub = (*pdfFontSimple)(nil)
+// pdfFontSimple implements PdfFont
+var _ PdfFont = (*pdfFontSimple)(nil)
 
 // pdfFontSimple describes a Simple Font
 //
@@ -429,7 +429,7 @@ func (font *pdfFontSimple) ToPdfObject() core.PdfObject {
 // NewPdfFontFromTTFFile loads a TTF font and returns a PdfFont type that can be used in text
 // styling functions.
 // Uses a WinAnsiTextEncoder and loads only character codes 32-255.
-func NewPdfFontFromTTFFile(filePath string) (*PdfFont, error) {
+func NewPdfFontFromTTFFile(filePath string) (PdfFont, error) {
 	const minCode = textencoding.CharCode(32)
 	const maxCode = textencoding.CharCode(255)
 
@@ -536,7 +536,7 @@ func NewPdfFontFromTTFFile(filePath string) (*PdfFont, error) {
 	// Build Font.
 	truefont.fontDescriptor = descriptor
 
-	return &PdfFont{truefont}, nil
+	return truefont, nil
 }
 
 // updateStandard14Font fills the font.charWidths for standard 14 fonts.

--- a/pdf/model/font_simple.go
+++ b/pdf/model/font_simple.go
@@ -146,10 +146,18 @@ func (font pdfFontSimple) GetRuneMetrics(r rune) (fonts.CharMetrics, bool) {
 		if r != ' ' {
 			common.Log.Trace("No charcode for rune=%v font=%s", r, font)
 		}
+		if d := font.fontDescriptor; d != nil {
+			return fonts.CharMetrics{Wx: d.missingWidth}, true
+		}
 		return fonts.CharMetrics{}, false
 	}
-	metrics, ok := font.GetCharMetrics(code)
-	return metrics, ok
+	metrics, found := font.GetCharMetrics(code)
+	if !found {
+		if d := font.fontDescriptor; d != nil {
+			return fonts.CharMetrics{Wx: d.missingWidth}, true
+		}
+	}
+	return metrics, found
 }
 
 // GetCharMetrics returns the character metrics for the specified character code.  A bool flag is

--- a/pdf/model/font_simple.go
+++ b/pdf/model/font_simple.go
@@ -101,6 +101,21 @@ func (font *pdfFontSimple) BuiltinDescriptor() bool {
 	return font.builtin
 }
 
+func (font *pdfFontSimple) BytesToCharcodes(data []byte) []textencoding.CharCode {
+	// TODO(dennwc): resolve branches and inline
+	return bytesToCharcodes(font, data)
+}
+
+func (font *pdfFontSimple) CharcodeBytesToUnicode(data []byte) (string, int, int) {
+	// TODO(dennwc): resolve branches and inline
+	return charcodeBytesToUnicode(font, data)
+}
+
+func (font *pdfFontSimple) CharcodesToUnicodeWithStats(charcodes []textencoding.CharCode) (runelist []rune, numHits, numMisses int) {
+	// TODO(dennwc): resolve branches and inline
+	return charcodesToUnicodeWithStats(font, charcodes)
+}
+
 // Encoder returns the font's text encoder.
 func (font *pdfFontSimple) Encoder() textencoding.TextEncoder {
 	// TODO(peterwilliams97): Need to make font.Encoder()==nil test work for

--- a/pdf/model/font_simple.go
+++ b/pdf/model/font_simple.go
@@ -70,6 +70,10 @@ func pdfFontSimpleFromSkeleton(base *fontCommon) *pdfFontSimple {
 	}
 }
 
+func (*pdfFontSimple) IsCID() bool {
+	return false
+}
+
 func (font *pdfFontSimple) BaseFont() string {
 	return font.basefont
 }
@@ -102,8 +106,12 @@ func (font *pdfFontSimple) BuiltinDescriptor() bool {
 }
 
 func (font *pdfFontSimple) BytesToCharcodes(data []byte) []textencoding.CharCode {
-	// TODO(dennwc): resolve branches and inline
-	return bytesToCharcodes(font, data)
+	common.Log.Trace("BytesToCharcodes: data=[% 02x]=%#q", data, data)
+	charcodes := make([]textencoding.CharCode, 0, len(data))
+	for _, b := range data {
+		charcodes = append(charcodes, textencoding.CharCode(b))
+	}
+	return charcodes
 }
 
 func (font *pdfFontSimple) CharcodeBytesToUnicode(data []byte) (string, int, int) {

--- a/pdf/model/font_simple.go
+++ b/pdf/model/font_simple.go
@@ -189,6 +189,9 @@ func (font pdfFontSimple) GetCharMetrics(code textencoding.CharCode) (fonts.Char
 		// PdfBox says this is what Acrobat does. Their reference is PDFBOX-2334.
 		return fonts.CharMetrics{Wx: 250}, true
 	}
+	if d := font.fontDescriptor; d != nil {
+		return fonts.CharMetrics{Wx: d.missingWidth}, true
+	}
 	return fonts.CharMetrics{}, false
 }
 

--- a/pdf/model/font_test.go
+++ b/pdf/model/font_test.go
@@ -127,9 +127,9 @@ func TestNewStandard14Font(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", in, err)
 		}
-		if font.Subtype() != expect.subtype || font.BaseFont() != expect.basefont {
+		if font.FullSubtype() != expect.subtype || font.BaseFont() != expect.basefont {
 			t.Fatalf("%s: expected BaseFont=%s SubType=%s, but got BaseFont=%s SubType=%s",
-				in, expect.basefont, expect.subtype, font.BaseFont(), font.Subtype())
+				in, expect.basefont, expect.subtype, font.BaseFont(), font.FullSubtype())
 		}
 
 		metrics, ok := font.GetRuneMetrics(' ')
@@ -284,7 +284,7 @@ func TestFontDescriptor(t *testing.T) {
 		t.Run(string(fontName), func(t *testing.T) {
 			font := model.NewStandard14FontMustCompile(fontName)
 
-			descriptor := font.FontDescriptor()
+			descriptor := font.GetFontDescriptor()
 			if descriptor == nil {
 				t.Fatalf("%#q: No descriptor.", fontName)
 			}

--- a/pdf/model/fonts/font.go
+++ b/pdf/model/fonts/font.go
@@ -17,6 +17,9 @@ import (
 type Font interface {
 	// Encoder returns the font's text encoder.
 	Encoder() textencoding.TextEncoder
+	// GetRuneMetrics returns the char metrics for rune `r`.
+	// TODO(peterwilliams97) There is nothing callers can do if no CharMetrics are found so we might as
+	//                       well give them 0 width. There is no need for the bool return.
 	GetRuneMetrics(r rune) (CharMetrics, bool)
 	// ToPdfObject converts the PdfFont object to its PDF representation.
 	ToPdfObject() core.PdfObject

--- a/pdf/model/fonts/font.go
+++ b/pdf/model/fonts/font.go
@@ -15,8 +15,10 @@ import (
 // Font represents a font which is a series of glyphs. Character codes from PDF strings can be
 // mapped to and from glyphs.  Each glyph has metrics.
 type Font interface {
+	// Encoder returns the font's text encoder.
 	Encoder() textencoding.TextEncoder
 	GetRuneMetrics(r rune) (CharMetrics, bool)
+	// ToPdfObject converts the PdfFont object to its PDF representation.
 	ToPdfObject() core.PdfObject
 }
 


### PR DESCRIPTION
The first round of changes to define the font interface.

PR removes a `PdfFont` proxy type and replaces it with an expanded `pdfFont` interface. All implementation details from `PdfFont` are pushed down to interface implementations.

An interface is still not final. It only resembles the same set of methods as `PdfFont`, while it can be improved to only contain ones that user would care about.

For example, there is a tendency to expose an API to convert `[]byte` -> `[]Charcode` -> `[]rune` on a higher level. This should only be a detail of one of the interface implementations, while an interface can do a direct `[]byte` -> `[]rune` conversion.