### PR TITLE
V3.imagemark

### DIFF
--- a/pdf/extractor/image.go
+++ b/pdf/extractor/image.go
@@ -47,7 +47,7 @@ type ImageMark struct {
 	X float64
 	Y float64
 
-	// Angle if rotated.
+	// Angle in degrees, if rotated.
 	Angle float64
 }
 

--- a/pdf/model/colorspace.go
+++ b/pdf/model/colorspace.go
@@ -1719,6 +1719,7 @@ func newPdfColorspaceICCBasedFromPdfObject(obj core.PdfObject) (*PdfColorspaceIC
 	}
 
 	obj = core.TraceToDirectObject(obj)
+
 	array, ok := obj.(*core.PdfObjectArray)
 	if !ok {
 		return nil, fmt.Errorf("type error")
@@ -1779,6 +1780,13 @@ func newPdfColorspaceICCBasedFromPdfObject(obj core.PdfObject) (*PdfColorspaceIC
 			return nil, err
 		}
 		cs.Range = r
+	} else {
+		// Set defaults
+		cs.Range = make([]float64, 2*cs.N)
+		for i := 0; i < cs.N; i++ {
+			cs.Range[2*i] = 0.0
+			cs.Range[2*i+1] = 1.0
+		}
 	}
 
 	if obj := dict.Get("Metadata"); obj != nil {
@@ -2513,9 +2521,9 @@ func (cs *PdfColorspaceSpecialSeparation) ImageToRGB(img Image) (Image, error) {
 
 	var altSamples []uint32
 	// Convert tints to color data in the alternate colorspace.
-	for i := 0; i < len(samples); i++ {
+	for _, sample := range samples {
 		// A single tint component is in the range 0.0 - 1.0
-		tint := float64(samples[i]) / maxVal
+		tint := float64(sample) / maxVal
 
 		// Convert the tint value to the alternate space value.
 		outputs, err := cs.TintTransform.Evaluate([]float64{tint})


### PR DESCRIPTION
Fix and test for ICC color spaces without default ranges.
I found this bug while testing the new image position code and added a test function to regression test it. 