### PR TITLE
Add text style rendering mode

### DIFF
--- a/pdf/creator/const.go
+++ b/pdf/creator/const.go
@@ -41,6 +41,39 @@ const (
 	TextAlignmentJustify
 )
 
+// TextRenderingMode determines whether showing text shall cause glyph
+// outlines to be stroked, filled, used as a clipping boundary, or some
+// combination of the three.
+// See section 9.3 "Text State Parameters and Operators" and
+// Table 106 (pp. 254-255 PDF32000_2008).
+type TextRenderingMode int
+
+const (
+	// TextRenderingModeFill (default) - Fill text.
+	TextRenderingModeFill TextRenderingMode = iota
+
+	// TextRenderingModeStroke - Stroke text.
+	TextRenderingModeStroke
+
+	// TextRenderingModeFillStroke - Fill, then stroke text.
+	TextRenderingModeFillStroke
+
+	// TextRenderingModeInvisible - Neither fill nor stroke text (invisible).
+	TextRenderingModeInvisible
+
+	// TextRenderingModeFillClip - Fill text and add to path for clipping.
+	TextRenderingModeFillClip
+
+	// TextRenderingModeStrokeClip - Stroke text and add to path for clipping.
+	TextRenderingModeStrokeClip
+
+	// TextRenderingModeFillStrokeClip - Fill, then stroke text and add to path for clipping.
+	TextRenderingModeFillStrokeClip
+
+	// TextRenderingModeClip - Add text to path for clipping.
+	TextRenderingModeClip
+)
+
 // Relative and absolute positioning types.
 type positioning int
 

--- a/pdf/creator/styled_paragraph.go
+++ b/pdf/creator/styled_paragraph.go
@@ -656,6 +656,9 @@ func drawStyledParagraphOnBlock(blk *Block, p *StyledParagraph, ctx DrawContext)
 			fontName := defaultFontName
 			fontSize := defaultFontSize
 
+			// Set chunk rendering mode.
+			cc.Add_Tr(int64(style.RenderingMode))
+
 			if p.alignment != TextAlignmentJustify || isLastLine {
 				spaceMetrics, found := style.Font.GetRuneMetrics(' ')
 				if !found {
@@ -744,6 +747,9 @@ func drawStyledParagraphOnBlock(blk *Block, p *StyledParagraph, ctx DrawContext)
 			}
 
 			currX += chunkWidth
+
+			// Reset rendering mode.
+			cc.Add_Tr(int64(TextRenderingModeFill))
 		}
 
 		currY -= height

--- a/pdf/creator/styled_paragraph_test.go
+++ b/pdf/creator/styled_paragraph_test.go
@@ -439,11 +439,11 @@ Sed imperdiet sodales lacus sed sollicitudin. In porta tortor quis augue tempor,
 
 func TestStyledParagraphRenderingModes(t *testing.T) {
 	fontRegular := newStandard14Font(t, fonts.HelveticaName)
-	//fontBold := newStandard14Font(t, fonts.HelveticaBoldName)
 
 	c := New()
 	c.NewPage()
 
+	// Showcase rendering modes.
 	tmodes := []TextRenderingMode{
 		TextRenderingModeFill,
 		TextRenderingModeStroke,
@@ -481,6 +481,23 @@ func TestStyledParagraphRenderingModes(t *testing.T) {
 	}
 
 	err := c.Draw(p)
+	if err != nil {
+		t.Fatalf("Error drawing: %v", err)
+	}
+
+	// Invisible, manually positioned paragraph.
+	p = c.NewStyledParagraph()
+	p.SetPos(150, 500)
+	chunk := p.Append("Invisible text >>> ")
+	chunk.Style.Font = fontRegular
+	chunk.Style.FontSize = 12
+
+	chunk = p.Append("Some invisible text manually positioned")
+	chunk.Style.Font = fontRegular
+	chunk.Style.FontSize = 15
+	chunk.Style.RenderingMode = TextRenderingModeInvisible
+
+	err = c.Draw(p)
 	if err != nil {
 		t.Fatalf("Error drawing: %v", err)
 	}

--- a/pdf/creator/styled_paragraph_test.go
+++ b/pdf/creator/styled_paragraph_test.go
@@ -436,3 +436,58 @@ Sed imperdiet sodales lacus sed sollicitudin. In porta tortor quis augue tempor,
 		t.Fatalf("Fail: %v\n", err)
 	}
 }
+
+func TestStyledParagraphRenderingModes(t *testing.T) {
+	fontRegular := newStandard14Font(t, fonts.HelveticaName)
+	//fontBold := newStandard14Font(t, fonts.HelveticaBoldName)
+
+	c := New()
+	c.NewPage()
+
+	tmodes := []TextRenderingMode{
+		TextRenderingModeFill,
+		TextRenderingModeStroke,
+		TextRenderingModeFillStroke,
+		TextRenderingModeInvisible,
+		TextRenderingModeFillClip,
+		TextRenderingModeStrokeClip,
+		TextRenderingModeFillStrokeClip,
+		TextRenderingModeClip,
+	}
+
+	tmodesDesc := []string{
+		"- Text rendering mode fill: ",
+		"- Text rendering mode stroke: ",
+		"- Text rendering mode fill and stroke: ",
+		"- Text rendering mode invisible: ",
+		"- Text rendering mode fill and clip: ",
+		"- Text rendering mode stroke and clip: ",
+		"- Text rendering mode fill, stroke and clip: ",
+		"- Text rendering mode clip: ",
+	}
+
+	p := c.NewStyledParagraph()
+	p.SetLineHeight(1.5)
+
+	for i, tmode := range tmodes {
+		chunk := p.Append(tmodesDesc[i])
+		chunk.Style.Font = fontRegular
+		chunk.Style.FontSize = 12
+
+		chunk = p.Append("This is some sample text\n")
+		chunk.Style.RenderingMode = tmode
+		chunk.Style.Font = fontRegular
+		chunk.Style.FontSize = 22
+	}
+
+	err := c.Draw(p)
+	if err != nil {
+		t.Fatalf("Error drawing: %v", err)
+	}
+
+	// Write output file.
+	err = c.WriteToFile(tempFile("styled_paragraph_rendering_mode.pdf"))
+	if err != nil {
+		t.Fatalf("Fail: %v\n", err)
+	}
+}

--- a/pdf/creator/text_style.go
+++ b/pdf/creator/text_style.go
@@ -19,6 +19,9 @@ type TextStyle struct {
 
 	// The size of the font.
 	FontSize float64
+
+	// The rendering mode.
+	RenderingMode TextRenderingMode
 }
 
 // newTextStyle creates a new text style object using the specified font.


### PR DESCRIPTION
Adds rendering mode field to the TextStyle structure. Also adds text chunks with different rendering modes  to the StyledParagraph component.

Should resolve #221 