### PR TITLE
Reduce memory thrashing when optimising large PDFs

### DIFF
--- a/pdf/core/primitives.go
+++ b/pdf/core/primitives.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/unidoc/unidoc/common"
 	"github.com/unidoc/unidoc/pdf/internal/strutils"
@@ -604,16 +605,17 @@ func (d *PdfObjectDictionary) String() string {
 
 // WriteString outputs the object as it is to be written to file.
 func (d *PdfObjectDictionary) WriteString() string {
-	outStr := "<<"
+	b := strings.Builder{}
+	b.WriteString("<<")
 	for _, k := range d.keys {
 		v := d.dict[k]
 		common.Log.Trace("Writing k: %s %T %v %v", k, v, k, v)
-		outStr += k.WriteString()
-		outStr += " "
-		outStr += v.WriteString()
+		b.WriteString(k.WriteString())
+		b.WriteString(" ")
+		b.WriteString(v.WriteString())
 	}
-	outStr += ">>"
-	return outStr
+	b.WriteString(">>")
+	return b.String()
 }
 
 // Set sets the dictionary's key -> val mapping entry. Overwrites if key already set.


### PR DESCRIPTION
Before this change `optimize.(*CombineDuplicateDirectObjects).Optimize` has spent 97% of it's runtime in `github.com/unidoc/unidoc/pdf/core.(*PdfObjectDictionary).WriteString` and optimising a 500 page PDF with 4 images / page took a couple minutes on 8-thread cpu

After the change it's <1% and optimising the same file takes seconds.

