### PR TITLE
Fixed bug in reading DecodeParems seen with CCITT images in gov.uscou…

### DIFF
--- a/pdf/core/encoding.go
+++ b/pdf/core/encoding.go
@@ -1712,16 +1712,21 @@ func newCCITTFaxEncoderFromStream(streamObj *PdfObjectStream, decodeParams *PdfO
 				break
 			case *PdfObjectArray:
 				if t.Len() == 1 {
-					if dp, isDict := t.Get(0).(*PdfObjectDictionary); isDict {
+					if dp, ok := GetDict(t.Get(0)); ok {
 						decodeParams = dp
 					}
 				}
 			default:
 				common.Log.Error("DecodeParms not a dictionary %#v", obj)
-				return nil, fmt.Errorf("Invalid DecodeParms")
+				return nil, errors.New("invalid DecodeParms")
 			}
 		}
+		if decodeParams == nil {
+			common.Log.Error("DecodeParms not specified %#v", obj)
+			return nil, errors.New("invalid DecodeParms")
+		}
 	}
+
 
 	if k, err := GetNumberAsInt64(decodeParams.Get("K")); err == nil {
 		encoder.K = int(k)


### PR DESCRIPTION
To test :
```
cd $GOPATH/src/github.com/unidoc/unidoc-examples/pdf/image
go run pdf_list_images.go gov.uscourts.ctd.18812.88.0.pdf
```
gov.uscourts.ctd.18812.88.0.pdf is in https://github.com/peterwilliams97/unidoc-testdata