### PR TITLE
Add image extraction options

### DIFF
--- a/pdf/extractor/image.go
+++ b/pdf/extractor/image.go
@@ -12,9 +12,9 @@ import (
 	"github.com/unidoc/unidoc/pdf/model"
 )
 
-// ExtractImagesOpts contains options for controlling image extraction from
+// ImageExtractOpts contains options for controlling image extraction from
 // PDF pages.
-type ExtractPageImagesOpts struct {
+type ImageExtractOpts struct {
 	IncludeInlineStencilMasks bool
 }
 
@@ -23,7 +23,7 @@ type ExtractPageImagesOpts struct {
 // A set of options to control page image extraction can be passed in. The opts
 // parameter can be nil for the default options. By default, inline stencil masks
 // are not extracted.
-func (e *Extractor) ExtractPageImages(opts *ExtractPageImagesOpts) (*PageImages, error) {
+func (e *Extractor) ExtractPageImages(opts *ImageExtractOpts) (*PageImages, error) {
 	ctx := &imageExtractContext{
 		opts: opts,
 	}
@@ -72,7 +72,7 @@ type imageExtractContext struct {
 	cacheXObjectImages map[*core.PdfObjectStream]*cachedImage
 
 	// Extract options.
-	opts *ExtractPageImagesOpts
+	opts *ImageExtractOpts
 }
 
 type cachedImage struct {
@@ -91,7 +91,7 @@ func (ctx *imageExtractContext) extractContentStreamImages(contents string, reso
 		ctx.cacheXObjectImages = map[*core.PdfObjectStream]*cachedImage{}
 	}
 	if ctx.opts == nil {
-		ctx.opts = &ExtractPageImagesOpts{}
+		ctx.opts = &ImageExtractOpts{}
 	}
 
 	processor := contentstream.NewContentStreamProcessor(*operations)

--- a/pdf/extractor/image.go
+++ b/pdf/extractor/image.go
@@ -12,10 +12,21 @@ import (
 	"github.com/unidoc/unidoc/pdf/model"
 )
 
+// ExtractImagesOpts contains options for controlling image extraction from
+// PDF pages.
+type ExtractPageImagesOpts struct {
+	IncludeInlineStencilMasks bool
+}
+
 // ExtractPageImages returns the image contents of the page extractor, including data
 // and position, size information for each image.
-func (e *Extractor) ExtractPageImages() (*PageImages, error) {
-	ctx := &imageExtractContext{}
+// A set of options to control page image extraction can be passed in. The opts
+// parameter can be nil for the default options. By default, inline stencil masks
+// are not extracted.
+func (e *Extractor) ExtractPageImages(opts *ExtractPageImagesOpts) (*PageImages, error) {
+	ctx := &imageExtractContext{
+		opts: opts,
+	}
 
 	err := ctx.extractContentStreamImages(e.contents, e.resources)
 	if err != nil {
@@ -59,6 +70,9 @@ type imageExtractContext struct {
 
 	// Cache to avoid processing same image many times.
 	cacheXObjectImages map[*core.PdfObjectStream]*cachedImage
+
+	// Extract options.
+	opts *ExtractPageImagesOpts
 }
 
 type cachedImage struct {
@@ -75,6 +89,9 @@ func (ctx *imageExtractContext) extractContentStreamImages(contents string, reso
 
 	if ctx.cacheXObjectImages == nil {
 		ctx.cacheXObjectImages = map[*core.PdfObjectStream]*cachedImage{}
+	}
+	if ctx.opts == nil {
+		ctx.opts = &ExtractPageImagesOpts{}
 	}
 
 	processor := contentstream.NewContentStreamProcessor(*operations)
@@ -93,6 +110,12 @@ func (ctx *imageExtractContext) processOperand(op *contentstream.ContentStreamOp
 		iimg, ok := op.Params[0].(*contentstream.ContentStreamInlineImage)
 		if !ok {
 			return nil
+		}
+
+		if isImageMask, ok := core.GetBoolVal(iimg.ImageMask); ok {
+			if isImageMask && !ctx.opts.IncludeInlineStencilMasks {
+				return nil
+			}
 		}
 
 		return ctx.extractInlineImage(iimg, gs, resources)

--- a/pdf/extractor/image.go
+++ b/pdf/extractor/image.go
@@ -12,20 +12,20 @@ import (
 	"github.com/unidoc/unidoc/pdf/model"
 )
 
-// ImageExtractOpts contains options for controlling image extraction from
+// ImageExtractOptions contains options for controlling image extraction from
 // PDF pages.
-type ImageExtractOpts struct {
+type ImageExtractOptions struct {
 	IncludeInlineStencilMasks bool
 }
 
 // ExtractPageImages returns the image contents of the page extractor, including data
 // and position, size information for each image.
-// A set of options to control page image extraction can be passed in. The opts
+// A set of options to control page image extraction can be passed in. The options
 // parameter can be nil for the default options. By default, inline stencil masks
 // are not extracted.
-func (e *Extractor) ExtractPageImages(opts *ImageExtractOpts) (*PageImages, error) {
+func (e *Extractor) ExtractPageImages(options *ImageExtractOptions) (*PageImages, error) {
 	ctx := &imageExtractContext{
-		opts: opts,
+		options: options,
 	}
 
 	err := ctx.extractContentStreamImages(e.contents, e.resources)
@@ -72,7 +72,7 @@ type imageExtractContext struct {
 	cacheXObjectImages map[*core.PdfObjectStream]*cachedImage
 
 	// Extract options.
-	opts *ImageExtractOpts
+	options *ImageExtractOptions
 }
 
 type cachedImage struct {
@@ -90,8 +90,8 @@ func (ctx *imageExtractContext) extractContentStreamImages(contents string, reso
 	if ctx.cacheXObjectImages == nil {
 		ctx.cacheXObjectImages = map[*core.PdfObjectStream]*cachedImage{}
 	}
-	if ctx.opts == nil {
-		ctx.opts = &ImageExtractOpts{}
+	if ctx.options == nil {
+		ctx.options = &ImageExtractOptions{}
 	}
 
 	processor := contentstream.NewContentStreamProcessor(*operations)
@@ -113,7 +113,7 @@ func (ctx *imageExtractContext) processOperand(op *contentstream.ContentStreamOp
 		}
 
 		if isImageMask, ok := core.GetBoolVal(iimg.ImageMask); ok {
-			if isImageMask && !ctx.opts.IncludeInlineStencilMasks {
+			if isImageMask && !ctx.options.IncludeInlineStencilMasks {
 				return nil
 			}
 		}

--- a/pdf/extractor/image_test.go
+++ b/pdf/extractor/image_test.go
@@ -87,7 +87,7 @@ func TestImageExtractionBasic(t *testing.T) {
 		pageExtractor, err := New(page)
 		require.NoError(t, err)
 
-		pageImages, err := pageExtractor.ExtractPageImages()
+		pageImages, err := pageExtractor.ExtractPageImages(nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, len(tcase.Expected), len(pageImages.Images))
@@ -177,7 +177,7 @@ func TestImageExtractionNestedCM(t *testing.T) {
 		pageExtractor, err := New(page)
 		require.NoError(t, err)
 
-		pageImages, err := pageExtractor.ExtractPageImages()
+		pageImages, err := pageExtractor.ExtractPageImages(nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, len(tcase.Expected), len(pageImages.Images))
@@ -222,7 +222,7 @@ func TestImageExtractionMulti(t *testing.T) {
 		pageExtractor, err := New(page)
 		require.NoError(t, err)
 
-		pageImages, err := pageExtractor.ExtractPageImages()
+		pageImages, err := pageExtractor.ExtractPageImages(nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, tcase.NumImages, len(pageImages.Images))
@@ -303,7 +303,7 @@ func TestImageExtractionRealWorld(t *testing.T) {
 		pageExtractor, err := New(page)
 		require.NoError(t, err)
 
-		pageImages, err := pageExtractor.ExtractPageImages()
+		pageImages, err := pageExtractor.ExtractPageImages(nil)
 		require.NoError(t, err)
 
 		if len(tcase.Expected) == 0 {
@@ -328,7 +328,7 @@ func BenchmarkImageExtraction(b *testing.B) {
 		pageExtractor, err := New(page)
 		require.NoError(b, err)
 
-		pageImages, err := pageExtractor.ExtractPageImages()
+		pageImages, err := pageExtractor.ExtractPageImages(nil)
 		require.NoError(b, err)
 
 		cnt += len(pageImages.Images)


### PR DESCRIPTION
- Add options to ExtractPageImages extractor method
- Skip extraction of inline stencil masks by default

Resolves #362