### PR TITLE
Fix incompatibility errors when loading various corpus PDF files [v3]

### DIFF
--- a/pdf/core/encoding.go
+++ b/pdf/core/encoding.go
@@ -181,21 +181,21 @@ func newFlateEncoderFromStream(streamObj *PdfObjectStream, decodeParams *PdfObje
 	// If decodeParams not provided, see if we can get from the stream.
 	if decodeParams == nil {
 		obj := TraceToDirectObject(encDict.Get("DecodeParms"))
-		if obj != nil {
-			if arr, isArr := obj.(*PdfObjectArray); isArr {
-				if arr.Len() != 1 {
-					common.Log.Debug("Error: DecodeParms array length != 1 (%d)", arr.Len())
-					return nil, errors.New("range check error")
-				}
-				obj = TraceToDirectObject(arr.Get(0))
+		switch t := obj.(type) {
+		case *PdfObjectArray:
+			arr := t
+			if arr.Len() != 1 {
+				common.Log.Debug("Error: DecodeParms array length != 1 (%d)", arr.Len())
+				return nil, errors.New("range check error")
 			}
-
-			dp, isDict := obj.(*PdfObjectDictionary)
-			if !isDict {
-				common.Log.Debug("Error: DecodeParms not a dictionary (%T)", obj)
-				return nil, fmt.Errorf("invalid DecodeParms")
-			}
-			decodeParams = dp
+			obj = TraceToDirectObject(arr.Get(0))
+		case *PdfObjectDictionary:
+			decodeParams = t
+		case *PdfObjectNull, nil:
+			// No decode params set.
+		default:
+			common.Log.Debug("Error: DecodeParms not a dictionary (%T)", obj)
+			return nil, fmt.Errorf("invalid DecodeParms")
 		}
 	}
 	if decodeParams == nil {
@@ -1897,8 +1897,8 @@ func (enc *CCITTFaxEncoder) DecodeBytes(encoded []byte) ([]byte, error) {
 		EndOfBlock:             enc.EndOfBlock,
 		BlackIs1:               enc.BlackIs1,
 		DamagedRowsBeforeError: enc.DamagedRowsBeforeError,
-		Rows:                   enc.Rows,
-		EncodedByteAlign:       enc.EncodedByteAlign,
+		Rows:             enc.Rows,
+		EncodedByteAlign: enc.EncodedByteAlign,
 	}
 
 	pixels, err := encoder.Decode(encoded)
@@ -1968,8 +1968,8 @@ func (enc *CCITTFaxEncoder) EncodeBytes(data []byte) ([]byte, error) {
 		EndOfBlock:             enc.EndOfBlock,
 		BlackIs1:               enc.BlackIs1,
 		DamagedRowsBeforeError: enc.DamagedRowsBeforeError,
-		Rows:                   enc.Rows,
-		EncodedByteAlign:       enc.EncodedByteAlign,
+		Rows:             enc.Rows,
+		EncodedByteAlign: enc.EncodedByteAlign,
 	}
 
 	return encoder.Encode(pixels), nil

--- a/pdf/model/annotations.go
+++ b/pdf/model/annotations.go
@@ -39,6 +39,9 @@ type PdfAnnotation struct {
 // GetContext returns the annotation context which contains the specific type-dependent context.
 // The context represents the subannotation.
 func (a *PdfAnnotation) GetContext() PdfModel {
+	if a == nil {
+		return nil
+	}
 	return a.context
 }
 
@@ -957,8 +960,8 @@ func (r *PdfReader) newPdfAnnotationFromIndirectObject(container *core.PdfIndire
 		return annot, nil
 	}
 
-	err := fmt.Errorf("unknown annotation (%s)", *subtype)
-	return nil, err
+	common.Log.Debug("ERROR: Ignoring unknown annotation: %s", *subtype)
+	return nil, nil
 }
 
 // Load data for markup annotation subtypes.
@@ -980,12 +983,13 @@ func (r *PdfReader) newPdfAnnotationMarkupFromDict(d *core.PdfObjectDictionary) 
 			if err != nil {
 				return nil, err
 			}
-			popupAnnot, isPopupAnnot := popupAnnotObj.context.(*PdfAnnotationPopup)
-			if !isPopupAnnot {
-				return nil, errors.New("object not referring to a popup annotation")
+			if popupAnnotObj != nil {
+				popupAnnot, isPopupAnnot := popupAnnotObj.context.(*PdfAnnotationPopup)
+				if !isPopupAnnot {
+					return nil, errors.New("object not referring to a popup annotation")
+				}
+				annot.Popup = popupAnnot
 			}
-
-			annot.Popup = popupAnnot
 		}
 	}
 

--- a/pdf/model/page.go
+++ b/pdf/model/page.go
@@ -359,7 +359,9 @@ func (r *PdfReader) LoadAnnotations(d *core.PdfObjectDictionary) ([]*PdfAnnotati
 		if err != nil {
 			return nil, err
 		}
-		annotations = append(annotations, annot)
+		if annot != nil {
+			annotations = append(annotations, annot)
+		}
 	}
 
 	return annotations, nil

--- a/pdf/model/reader.go
+++ b/pdf/model/reader.go
@@ -363,7 +363,7 @@ func (r *PdfReader) buildOutlineTree(obj core.PdfObject, parent *PdfOutlineTreeN
 			return nil, nil, err
 		}
 		firstObjDirect := core.TraceToDirectObject(firstObj)
-		if _, isNull := firstObjDirect.(*core.PdfObjectNull); !isNull {
+		if _, isNull := firstObjDirect.(*core.PdfObjectNull); !isNull && firstObjDirect != nil {
 			first, last, err := r.buildOutlineTree(firstObj, &outline.PdfOutlineTreeNode, nil)
 			if err != nil {
 				return nil, nil, err

--- a/pdf/model/reader.go
+++ b/pdf/model/reader.go
@@ -362,7 +362,8 @@ func (r *PdfReader) buildOutlineTree(obj core.PdfObject, parent *PdfOutlineTreeN
 		if err != nil {
 			return nil, nil, err
 		}
-		if _, isNull := firstObj.(*core.PdfObjectNull); !isNull {
+		firstObjDirect := core.TraceToDirectObject(firstObj)
+		if _, isNull := firstObjDirect.(*core.PdfObjectNull); !isNull {
 			first, last, err := r.buildOutlineTree(firstObj, &outline.PdfOutlineTreeNode, nil)
 			if err != nil {
 				return nil, nil, err

--- a/pdf/model/signature.go
+++ b/pdf/model/signature.go
@@ -170,7 +170,7 @@ func (sig *PdfSignature) ToPdfObject() core.PdfObject {
 		dict = container.PdfObject.(*core.PdfObjectDictionary)
 	}
 
-	dict.Set("Type", sig.Type)
+	dict.SetIfNotNil("Type", sig.Type)
 	dict.SetIfNotNil("Filter", sig.Filter)
 	dict.SetIfNotNil("SubFilter", sig.SubFilter)
 	dict.SetIfNotNil("ByteRange", sig.ByteRange)
@@ -183,9 +183,7 @@ func (sig *PdfSignature) ToPdfObject() core.PdfObject {
 	dict.SetIfNotNil("Changes", sig.Changes)
 	dict.SetIfNotNil("ContactInfo", sig.ContactInfo)
 
-	// NOTE: ByteRange and Contents need to be updated dynamically.
-	// TODO: Currently dynamic update is only in the appender, need to support
-	// in the PdfWriter too for the initial signature on document creation.
+	// NOTE: ByteRange and Contents are updated dynamically (appender).
 	return container
 }
 
@@ -205,11 +203,7 @@ func (r *PdfReader) newPdfSignatureFromIndirect(container *core.PdfIndirectObjec
 	sig := &PdfSignature{}
 	sig.container = container
 
-	sig.Type, ok = core.GetName(dict.Get("Type"))
-	if !ok {
-		common.Log.Error("ERROR: Signature Type attribute invalid or missing")
-		return nil, ErrInvalidAttribute
-	}
+	sig.Type, _ = core.GetName(dict.Get("Type"))
 
 	sig.Filter, ok = core.GetName(dict.Get("Filter"))
 	if !ok {


### PR DESCRIPTION
Fixes for loading various corpus PDF files that can be loaded by ghostscript.  Addresses 4 error types that were seen.
- invalid-attribute
- invalid-decode-params
- not-a-dictionary-object
- unknown-annotation-linkid