### PR TITLE
No break space character metrics

### DIFF
--- a/pdf/model/font_test.go
+++ b/pdf/model/font_test.go
@@ -133,7 +133,19 @@ func TestNewStandard14Font(t *testing.T) {
 				in, expect.basefont, expect.subtype, font.BaseFont(), font.Subtype())
 		}
 
+		// Test space character metrics.
 		metrics, ok := font.GetRuneMetrics(' ')
+		if !ok {
+			t.Fatalf("%s: failed to get glyph metric", in)
+		}
+		if metrics.Wx != expect.Wx || metrics.Wy != expect.Wy {
+			t.Fatalf("%s: expected glyph metrics is Wx=%f Wy=%f, but got Wx=%f Wy=%f",
+				in, expect.Wx, expect.Wy, metrics.Wx, metrics.Wy)
+		}
+
+		// Test no-break space character metrics.
+		// Values should be the same as the metrics for regular space.
+		metrics, ok = font.GetRuneMetrics(0xA0)
 		if !ok {
 			t.Fatalf("%s: failed to get glyph metric", in)
 		}

--- a/pdf/model/internal/fonts/std.go
+++ b/pdf/model/internal/fonts/std.go
@@ -83,6 +83,12 @@ func NewStdFont(desc Descriptor, metrics map[rune]CharMetrics) StdFont {
 
 // NewStdFontWithEncoding returns a new instance of the font with a specified encoder.
 func NewStdFontWithEncoding(desc Descriptor, metrics map[rune]CharMetrics, encoder textencoding.TextEncoder) StdFont {
+	var nbsp rune = 0xA0
+	if _, ok := metrics[nbsp]; !ok {
+		// Use same metrics for 0xA0 (no-break space) and 0x20 (space).
+		metrics[nbsp] = metrics[0x20]
+	}
+
 	return StdFont{
 		desc:    desc,
 		metrics: metrics,


### PR DESCRIPTION
Use regular `space` character metrics for the `no-break space` character if nbsp handling is not already defined.
Addresses #396 