### PR TITLE
Fix invalid pad length [v3]

### DIFF
--- a/pdf/core/security/crypt/filter_aesv3.go
+++ b/pdf/core/security/crypt/filter_aesv3.go
@@ -140,10 +140,9 @@ func (filterAES) DecryptBytes(buf []byte, okey []byte) ([]byte, error) {
 	}
 
 	// The padded length is indicated by the last values.  Remove those.
-
 	padLen := int(buf[len(buf)-1])
-	if padLen >= len(buf) {
-		common.Log.Debug("Illegal pad length")
+	if padLen > len(buf) {
+		common.Log.Debug("Illegal pad length (%d >= %d)", padLen, len(buf))
 		return buf, fmt.Errorf("invalid pad length")
 	}
 	buf = buf[:len(buf)-padLen]

--- a/pdf/core/security/crypt/filter_aesv3.go
+++ b/pdf/core/security/crypt/filter_aesv3.go
@@ -142,7 +142,7 @@ func (filterAES) DecryptBytes(buf []byte, okey []byte) ([]byte, error) {
 	// The padded length is indicated by the last values.  Remove those.
 	padLen := int(buf[len(buf)-1])
 	if padLen > len(buf) {
-		common.Log.Debug("Illegal pad length (%d >= %d)", padLen, len(buf))
+		common.Log.Debug("Illegal pad length (%d > %d)", padLen, len(buf))
 		return buf, fmt.Errorf("invalid pad length")
 	}
 	buf = buf[:len(buf)-padLen]


### PR DESCRIPTION
Addresses #412 
- Fix when padLen == len(buf). Allows to clear entire buffer.