### PR TITLE
Fix v3 build: Compile pkcs11 examples with cgo enabled

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,9 +114,13 @@ node {
             
             // Dependencies for examples.
             sh 'go get github.com/wcharczuk/go-chart'
+            sh 'CGO_ENABLED=1 go get github.com/miekg/pkcs11'
+            sh 'CGO_ENABLED=1 go get github.com/ThalesIgnite/crypto11'
 
             // Build all examples.
-            sh 'find . -name "*.go" -print0 | xargs -0 -n1 go build'
+            // CGO_ENABLED=1 required for crypto11 dependency (one example).
+            sh 'find . -name "*.go" ! -name "*pkcs11*.go" -print0 | xargs -0 -n1 go build'
+            sh 'find . -name "*pkcs11*.go" -print0 | CGO_ENABLED=1 xargs -0 -n1 go build'
         }
 
         stage('Passthrough benchmark pdfdb_small') {


### PR DESCRIPTION
Errors when trying to compile new pkcs11 signature examples with cgo disabled.  This addresses that and specifically enables cgo where needed.