### PR TITLE
Cross reference search speed improvements [v3]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,9 +114,13 @@ node {
             
             // Dependencies for examples.
             sh 'go get github.com/wcharczuk/go-chart'
+            sh 'CGO_ENABLED=1 go get github.com/miekg/pkcs11'
+            sh 'CGO_ENABLED=1 go get github.com/ThalesIgnite/crypto11'
 
             // Build all examples.
-            sh 'find . -name "*.go" -print0 | xargs -0 -n1 go build'
+            // CGO_ENABLED=1 required for crypto11 dependency (one example).
+            sh 'find . -name "*.go" ! -name "*pkcs11*.go" -print0 | xargs -0 -n1 go build'
+            sh 'find . -name "*pkcs11*.go" -print0 | CGO_ENABLED=1 xargs -0 -n1 go build'
         }
 
         stage('Passthrough benchmark pdfdb_small') {

--- a/pdf/core/crossrefs.go
+++ b/pdf/core/crossrefs.go
@@ -43,7 +43,12 @@ type XrefObject struct {
 
 // XrefTable is a map between object number and corresponding XrefObject.
 // TODO: Consider changing to a slice, so can maintain the object order without sorting when analyzing.
-type XrefTable map[int]XrefObject
+type XrefTable struct {
+	ObjectMap map[int]XrefObject // Maps object number to XrefObject
+
+	// List of objects sorted by offset (only objects with offsets, not ones in streams).
+	sortedObjects []XrefObject
+}
 
 // objectStream represents an object stream's information which can contain multiple indirect objects.
 // The information specifies the number of objects and has information about offset locations for
@@ -238,7 +243,7 @@ func (parser *PdfParser) lookupByNumber(objNumber int, attemptRepairs bool) (Pdf
 		return obj, false, nil
 	}
 
-	xref, ok := parser.xrefs[objNumber]
+	xref, ok := parser.xrefs.ObjectMap[objNumber]
 	if !ok {
 		// An indirect reference to an undefined object shall not be
 		// considered an error by a conforming reader; it shall be
@@ -305,7 +310,7 @@ func (parser *PdfParser) lookupByNumber(objNumber int, attemptRepairs bool) (Pdf
 			return nil, true, errors.New("xref circular reference")
 		}
 
-		if _, exists := parser.xrefs[xref.OsObjNumber]; exists {
+		if _, exists := parser.xrefs.ObjectMap[xref.OsObjNumber]; exists {
 			optr, err := parser.lookupObjectViaOS(xref.OsObjNumber, objNumber) //xref.OsObjIndex)
 			if err != nil {
 				common.Log.Debug("ERROR Returning ERR (%s)", err)
@@ -367,7 +372,7 @@ func printXrefTable(xrefTable XrefTable) {
 	common.Log.Debug("=X=X=X=")
 	common.Log.Debug("Xref table:")
 	i := 0
-	for _, xref := range xrefTable {
+	for _, xref := range xrefTable.ObjectMap {
 		common.Log.Debug("i+1: %d (obj num: %d gen: %d) -> %d", i+1, xref.ObjectNumber, xref.Generation, xref.Offset)
 		i++
 	}

--- a/pdf/core/crossrefs.go
+++ b/pdf/core/crossrefs.go
@@ -41,8 +41,8 @@ type XrefObject struct {
 	OsObjIndex  int
 }
 
-// XrefTable is a map between object number and corresponding XrefObject.
-// TODO: Consider changing to a slice, so can maintain the object order without sorting when analyzing.
+// XrefTable represents the cross references in a PDF, i.e. the table of objects and information
+// where to access within the PDF file.
 type XrefTable struct {
 	ObjectMap map[int]XrefObject // Maps object number to XrefObject
 

--- a/pdf/core/crossrefs_test.go
+++ b/pdf/core/crossrefs_test.go
@@ -21,25 +21,27 @@ func TestParseXRefs(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := XrefTable{
-		17: {XType: 0, ObjectNumber: 17, Generation: 0, Offset: 427290, OsObjNumber: 0, OsObjIndex: 0},
-		55: {XType: 0, ObjectNumber: 55, Generation: 0, Offset: 427442, OsObjNumber: 0, OsObjIndex: 0},
-		79: {XType: 0, ObjectNumber: 79, Generation: 0, Offset: 427487, OsObjNumber: 0, OsObjIndex: 0},
-		80: {XType: 0, ObjectNumber: 80, Generation: 0, Offset: 427921, OsObjNumber: 0, OsObjIndex: 0},
-		81: {XType: 0, ObjectNumber: 81, Generation: 0, Offset: 428071, OsObjNumber: 0, OsObjIndex: 0},
-		82: {XType: 0, ObjectNumber: 82, Generation: 0, Offset: 429516, OsObjNumber: 0, OsObjIndex: 0},
-		83: {XType: 0, ObjectNumber: 83, Generation: 0, Offset: 429601, OsObjNumber: 0, OsObjIndex: 0},
-		84: {XType: 0, ObjectNumber: 84, Generation: 0, Offset: 429640, OsObjNumber: 0, OsObjIndex: 0},
-		85: {XType: 0, ObjectNumber: 85, Generation: 0, Offset: 429679, OsObjNumber: 0, OsObjIndex: 0},
-		86: {XType: 0, ObjectNumber: 86, Generation: 0, Offset: 429714, OsObjNumber: 0, OsObjIndex: 0},
-		87: {XType: 0, ObjectNumber: 87, Generation: 0, Offset: 429765, OsObjNumber: 0, OsObjIndex: 0},
-		88: {XType: 0, ObjectNumber: 88, Generation: 0, Offset: 429816, OsObjNumber: 0, OsObjIndex: 0},
-		89: {XType: 0, ObjectNumber: 89, Generation: 0, Offset: 429877, OsObjNumber: 0, OsObjIndex: 0},
-		90: {XType: 0, ObjectNumber: 90, Generation: 0, Offset: 429948, OsObjNumber: 0, OsObjIndex: 0},
-		91: {XType: 0, ObjectNumber: 91, Generation: 0, Offset: 430019, OsObjNumber: 0, OsObjIndex: 0},
-		92: {XType: 0, ObjectNumber: 92, Generation: 0, Offset: 430054, OsObjNumber: 0, OsObjIndex: 0},
-		// Additional object (not in index):
-		// Modified such that offset is 0 and number corrected.
-		94: {XType: 0, ObjectNumber: 94, Generation: 0, Offset: 0, OsObjNumber: 0, OsObjIndex: 0},
+		ObjectMap: map[int]XrefObject{
+			17: {XType: 0, ObjectNumber: 17, Generation: 0, Offset: 427290, OsObjNumber: 0, OsObjIndex: 0},
+			55: {XType: 0, ObjectNumber: 55, Generation: 0, Offset: 427442, OsObjNumber: 0, OsObjIndex: 0},
+			79: {XType: 0, ObjectNumber: 79, Generation: 0, Offset: 427487, OsObjNumber: 0, OsObjIndex: 0},
+			80: {XType: 0, ObjectNumber: 80, Generation: 0, Offset: 427921, OsObjNumber: 0, OsObjIndex: 0},
+			81: {XType: 0, ObjectNumber: 81, Generation: 0, Offset: 428071, OsObjNumber: 0, OsObjIndex: 0},
+			82: {XType: 0, ObjectNumber: 82, Generation: 0, Offset: 429516, OsObjNumber: 0, OsObjIndex: 0},
+			83: {XType: 0, ObjectNumber: 83, Generation: 0, Offset: 429601, OsObjNumber: 0, OsObjIndex: 0},
+			84: {XType: 0, ObjectNumber: 84, Generation: 0, Offset: 429640, OsObjNumber: 0, OsObjIndex: 0},
+			85: {XType: 0, ObjectNumber: 85, Generation: 0, Offset: 429679, OsObjNumber: 0, OsObjIndex: 0},
+			86: {XType: 0, ObjectNumber: 86, Generation: 0, Offset: 429714, OsObjNumber: 0, OsObjIndex: 0},
+			87: {XType: 0, ObjectNumber: 87, Generation: 0, Offset: 429765, OsObjNumber: 0, OsObjIndex: 0},
+			88: {XType: 0, ObjectNumber: 88, Generation: 0, Offset: 429816, OsObjNumber: 0, OsObjIndex: 0},
+			89: {XType: 0, ObjectNumber: 89, Generation: 0, Offset: 429877, OsObjNumber: 0, OsObjIndex: 0},
+			90: {XType: 0, ObjectNumber: 90, Generation: 0, Offset: 429948, OsObjNumber: 0, OsObjIndex: 0},
+			91: {XType: 0, ObjectNumber: 91, Generation: 0, Offset: 430019, OsObjNumber: 0, OsObjIndex: 0},
+			92: {XType: 0, ObjectNumber: 92, Generation: 0, Offset: 430054, OsObjNumber: 0, OsObjIndex: 0},
+			// Additional object (not in index):
+			// Modified such that offset is 0 and number corrected.
+			94: {XType: 0, ObjectNumber: 94, Generation: 0, Offset: 0, OsObjNumber: 0, OsObjIndex: 0},
+		},
 	}
 
 	require.Equal(t, expected, p.xrefs)

--- a/pdf/core/crypt_test.go
+++ b/pdf/core/crypt_test.go
@@ -62,7 +62,7 @@ func TestDecryption1(t *testing.T) {
 	rawText := "2 0 obj\n<< /Length 55 >>\nstream\n" + string(streamData) + "\nendstream\n"
 
 	parser := PdfParser{}
-	parser.xrefs = make(XrefTable)
+	parser.xrefs.ObjectMap = make(map[int]XrefObject)
 	parser.objstms = make(objectStreams)
 	parser.rs, parser.reader, parser.fileSize = makeReaderForText(rawText)
 	parser.crypter = &crypter

--- a/pdf/core/fuzz_test.go
+++ b/pdf/core/fuzz_test.go
@@ -50,13 +50,13 @@ endstream
 `
 
 	parser := PdfParser{}
-	parser.xrefs = make(XrefTable)
+	parser.xrefs.ObjectMap = make(map[int]XrefObject)
 	parser.objstms = make(objectStreams)
 	parser.rs, parser.reader, parser.fileSize = makeReaderForText(rawText)
 	parser.streamLengthReferenceLookupInProgress = map[int64]bool{}
 
 	// Point to the start of the stream (where obj 13 starts).
-	parser.xrefs[13] = XrefObject{
+	parser.xrefs.ObjectMap[13] = XrefObject{
 		XrefTypeTableEntry,
 		13,
 		0,
@@ -83,14 +83,14 @@ endstream
 `
 
 	parser := PdfParser{}
-	parser.xrefs = make(XrefTable)
+	parser.xrefs.ObjectMap = make(map[int]XrefObject)
 	parser.objstms = make(objectStreams)
 	parser.rs, parser.reader, parser.fileSize = makeReaderForText(rawText)
 	parser.streamLengthReferenceLookupInProgress = map[int64]bool{}
 
 	// Point to the start of the stream (where obj 13 starts).
 	// NOTE: using incorrect object number here:
-	parser.xrefs[12] = XrefObject{
+	parser.xrefs.ObjectMap[12] = XrefObject{
 		XrefTypeTableEntry,
 		12,
 		0,

--- a/pdf/core/parser.go
+++ b/pdf/core/parser.go
@@ -1076,7 +1076,7 @@ func (parser *PdfParser) parseXrefStream(xstm *PdfObjectInteger) (*PdfObjectDict
 				obj := XrefObject{ObjectNumber: objNum,
 					XType: XrefTypeObjectStream, OsObjNumber: int(n2), OsObjIndex: int(n3)}
 				parser.xrefs.ObjectMap[objNum] = obj
-				common.Log.Trace("entry: %+v", parser.xrefs.ObjectMap[objNum])
+				common.Log.Trace("entry: %+v", obj)
 			}
 		} else {
 			common.Log.Debug("ERROR: --------INVALID TYPE XrefStm invalid?-------")
@@ -1360,7 +1360,7 @@ func (parser *PdfParser) xrefNextObjectOffset(offset int64) int64 {
 			}
 		}
 
-		// Sort by offset, descending.
+		// Sort by offset, ascending.
 		sort.Slice(parser.xrefs.sortedObjects, func(i, j int) bool {
 			return parser.xrefs.sortedObjects[i].Offset < parser.xrefs.sortedObjects[j].Offset
 		})

--- a/pdf/core/parser.go
+++ b/pdf/core/parser.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -788,12 +789,12 @@ func (parser *PdfParser) parseXrefTable() (*PdfObjectDictionary, error) {
 				// Load if not existing or higher generation number than previous.
 				// Usually should not happen, lower generation numbers
 				// would be marked as free.  But can still happen!
-				x, ok := parser.xrefs[curObjNum]
+				x, ok := parser.xrefs.ObjectMap[curObjNum]
 				if !ok || gen > x.Generation {
 					obj := XrefObject{ObjectNumber: curObjNum,
 						XType:  XrefTypeTableEntry,
 						Offset: first, Generation: gen}
-					parser.xrefs[curObjNum] = obj
+					parser.xrefs.ObjectMap[curObjNum] = obj
 				}
 			}
 
@@ -1061,21 +1062,21 @@ func (parser *PdfParser) parseXrefStream(xstm *PdfObjectInteger) (*PdfObjectDict
 
 			// Object type 1: Objects that are in use but are not
 			// compressed, i.e. defined by an offset (normal entry)
-			if xr, ok := parser.xrefs[objNum]; !ok || int(n3) > xr.Generation {
+			if xr, ok := parser.xrefs.ObjectMap[objNum]; !ok || int(n3) > xr.Generation {
 				// Only overload if not already loaded!
 				// or has a newer generation number. (should not happen)
 				obj := XrefObject{ObjectNumber: objNum,
 					XType: XrefTypeTableEntry, Offset: n2, Generation: int(n3)}
-				parser.xrefs[objNum] = obj
+				parser.xrefs.ObjectMap[objNum] = obj
 			}
 		} else if ftype == 2 {
 			// Object type 2: Compressed object.
 			common.Log.Trace("- In use - compressed object")
-			if _, ok := parser.xrefs[objNum]; !ok {
+			if _, ok := parser.xrefs.ObjectMap[objNum]; !ok {
 				obj := XrefObject{ObjectNumber: objNum,
 					XType: XrefTypeObjectStream, OsObjNumber: int(n2), OsObjIndex: int(n3)}
-				parser.xrefs[objNum] = obj
-				common.Log.Trace("entry: %+v", parser.xrefs[objNum])
+				parser.xrefs.ObjectMap[objNum] = obj
+				common.Log.Trace("entry: %+v", parser.xrefs.ObjectMap[objNum])
 			}
 		} else {
 			common.Log.Debug("ERROR: --------INVALID TYPE XrefStm invalid?-------")
@@ -1193,7 +1194,7 @@ func (parser *PdfParser) seekToEOFMarker(fSize int64) error {
 // loaded will ignore older versions.
 //
 func (parser *PdfParser) loadXrefs() (*PdfObjectDictionary, error) {
-	parser.xrefs = make(XrefTable)
+	parser.xrefs.ObjectMap = make(map[int]XrefObject)
 	parser.objstms = make(objectStreams)
 
 	// Get the file size.
@@ -1333,11 +1334,45 @@ func (parser *PdfParser) loadXrefs() (*PdfObjectDictionary, error) {
 // Return the closest object following offset from the xrefs table.
 func (parser *PdfParser) xrefNextObjectOffset(offset int64) int64 {
 	nextOffset := int64(0)
-	for _, xref := range parser.xrefs {
-		if xref.Offset > offset && (xref.Offset < nextOffset || nextOffset == 0) {
-			nextOffset = xref.Offset
-		}
+
+	if len(parser.xrefs.ObjectMap) == 0 {
+		return 0
 	}
+
+	if len(parser.xrefs.sortedObjects) == 0 {
+		count := 0
+		for _, xref := range parser.xrefs.ObjectMap {
+			if xref.Offset > 0 {
+				count++
+			}
+		}
+		if count == 0 {
+			// No objects with offset.
+			return 0
+		}
+		parser.xrefs.sortedObjects = make([]XrefObject, count)
+
+		i := 0
+		for _, xref := range parser.xrefs.ObjectMap {
+			if xref.Offset > 0 {
+				parser.xrefs.sortedObjects[i] = xref
+				i++
+			}
+		}
+
+		// Sort by offset, descending.
+		sort.Slice(parser.xrefs.sortedObjects, func(i, j int) bool {
+			return parser.xrefs.sortedObjects[i].Offset < parser.xrefs.sortedObjects[j].Offset
+		})
+	}
+
+	i := sort.Search(len(parser.xrefs.sortedObjects), func(i int) bool {
+		return parser.xrefs.sortedObjects[i].Offset >= offset
+	})
+	if i < len(parser.xrefs.sortedObjects) {
+		nextOffset = parser.xrefs.sortedObjects[i].Offset
+	}
+
 	return nextOffset
 }
 
@@ -1563,7 +1598,7 @@ func NewParserFromString(txt string) *PdfParser {
 	parser.fileSize = int64(len(txt))
 	parser.streamLengthReferenceLookupInProgress = map[int64]bool{}
 
-	parser.xrefs = XrefTable{}
+	parser.xrefs.ObjectMap = make(map[int]XrefObject)
 
 	return &parser
 }
@@ -1586,7 +1621,7 @@ func NewParser(rs io.ReadSeeker) (*PdfParser, error) {
 
 	common.Log.Trace("Trailer: %s", trailer)
 
-	if len(parser.xrefs) == 0 {
+	if len(parser.xrefs.ObjectMap) == 0 {
 		return nil, fmt.Errorf("empty XREF table - Invalid")
 	}
 

--- a/pdf/core/parser_test.go
+++ b/pdf/core/parser_test.go
@@ -568,7 +568,7 @@ stream
 endstream
 endobj`
 	parser := PdfParser{}
-	parser.xrefs = make(XrefTable)
+	parser.xrefs.ObjectMap = make(map[int]XrefObject)
 	parser.objstms = make(objectStreams)
 	parser.rs, parser.reader, parser.fileSize = makeReaderForText(rawText)
 
@@ -584,20 +584,20 @@ endobj`
 		return
 	}
 
-	if len(parser.xrefs) != 4 {
-		t.Errorf("Wrong length (%d)", len(parser.xrefs))
+	if len(parser.xrefs.ObjectMap) != 4 {
+		t.Errorf("Wrong length (%d)", len(parser.xrefs.ObjectMap))
 		return
 	}
 
-	if parser.xrefs[3].XType != XrefTypeObjectStream {
+	if parser.xrefs.ObjectMap[3].XType != XrefTypeObjectStream {
 		t.Errorf("Invalid type")
 		return
 	}
-	if parser.xrefs[3].OsObjNumber != 15 {
+	if parser.xrefs.ObjectMap[3].OsObjNumber != 15 {
 		t.Errorf("Wrong object stream obj number")
 		return
 	}
-	if parser.xrefs[3].OsObjIndex != 2 {
+	if parser.xrefs.ObjectMap[3].OsObjIndex != 2 {
 		t.Errorf("Wrong object stream obj index")
 		return
 	}
@@ -714,101 +714,56 @@ func TestObjectParse(t *testing.T) {
 // TestMinimalPDFFile test basic parsing of a minimal pdf file.
 func TestMinimalPDFFile(t *testing.T) {
 	file, err := os.Open("./testdata/minimal.pdf")
-	if err != nil {
-		t.Errorf("Unable to open minimal test file (%s)", err)
-		return
-	}
+	require.NoError(t, err)
 	defer file.Close()
 
 	parser, err := NewParser(file)
-	if err != nil {
-		t.Errorf("Unable to parse test file: %v", err)
-		return
-	}
+	require.NoError(t, err)
 
-	if len(parser.xrefs) != 4 {
-		t.Errorf("Wrong number of xrefs %d != 4", len(parser.xrefs))
-	}
-
-	if parser.xrefs[1].ObjectNumber != 1 {
-		t.Errorf("Invalid xref0 object number != 1 (%d)", parser.xrefs[0].ObjectNumber)
-	}
-	if parser.xrefs[1].Offset != 18 {
-		t.Errorf("Invalid Offset != 18 (%d)", parser.xrefs[0].Offset)
-	}
-	if parser.xrefs[1].XType != XrefTypeTableEntry {
-		t.Errorf("Invalid xref type")
-	}
-	if parser.xrefs[3].ObjectNumber != 3 {
-		t.Errorf("Invalid xref object number != 3 (%d)", parser.xrefs[2].ObjectNumber)
-	}
-	if parser.xrefs[3].Offset != 178 {
-		t.Errorf("Invalid Offset != 178")
-	}
-	if parser.xrefs[3].XType != XrefTypeTableEntry {
-		t.Errorf("Invalid xref type")
-	}
+	require.Len(t, parser.xrefs.ObjectMap, 4)
+	require.Equal(t, 1, parser.xrefs.ObjectMap[1].ObjectNumber)
+	require.Equal(t, 18, parser.xrefs.ObjectMap[1].Offset)
+	require.Equal(t, XrefTypeTableEntry, parser.xrefs.ObjectMap[1].XType)
+	require.Equal(t, 3, parser.xrefs.ObjectMap[3].ObjectNumber)
+	require.Equal(t, 178, parser.xrefs.ObjectMap[3].Offset)
+	require.Equal(t, XrefTypeTableEntry, parser.xrefs.ObjectMap[3].XType)
 
 	// Check catalog object.
 	catalogObj, err := parser.LookupByNumber(1)
-	if err != nil {
-		t.Error("Unable to look up catalog object")
-	}
+	require.NoError(t, err)
+
 	catalog, ok := catalogObj.(*PdfIndirectObject)
-	if !ok {
-		t.Error("Unable to look up catalog object")
-	}
+	require.True(t, ok)
+
 	catalogDict, ok := catalog.PdfObject.(*PdfObjectDictionary)
-	if !ok {
-		t.Error("Unable to find dictionary")
-	}
+	require.True(t, ok)
+
 	typename, ok := catalogDict.Get("Type").(*PdfObjectName)
-	if !ok {
-		t.Error("Unable to check type")
-	}
-	if *typename != "Catalog" {
-		t.Errorf("Wrong type name (%s != Catalog)", *typename)
-	}
+	require.True(t, ok)
+	require.Equal(t, "Catalog", typename.String())
 
 	// Check Page object.
 	pageObj, err := parser.LookupByNumber(3)
-	if err != nil {
-		t.Fatalf("Unable to look up Page")
-	}
+	require.NoError(t, err)
+
 	page, ok := pageObj.(*PdfIndirectObject)
-	if !ok {
-		t.Fatalf("Unable to look up Page")
-	}
+	require.True(t, ok)
 	pageDict, ok := page.PdfObject.(*PdfObjectDictionary)
-	if !ok {
-		t.Fatalf("Unable to load Page dictionary")
-	}
-	if len(pageDict.Keys()) != 4 {
-		t.Fatalf("Page dict should have 4 objects (%d)", len(pageDict.Keys()))
-	}
+	require.True(t, ok)
+	require.Len(t, pageDict.Keys(), 4)
+
 	resourcesDict, ok := pageDict.Get("Resources").(*PdfObjectDictionary)
-	if !ok {
-		t.Fatalf("Unable to load Resources dictionary")
-	}
-	if len(resourcesDict.Keys()) != 1 {
-		t.Fatalf("Page Resources dict should have 1 member (%d)", len(resourcesDict.Keys()))
-	}
+	require.True(t, ok)
+	require.Len(t, resourcesDict.Keys(), 1)
+
 	fontDict, ok := resourcesDict.Get("Font").(*PdfObjectDictionary)
-	if !ok {
-		t.Error("Unable to load font")
-	}
+	require.True(t, ok)
+
 	f1Dict, ok := fontDict.Get("F1").(*PdfObjectDictionary)
-	if !ok {
-		t.Error("Unable to load F1 dict")
-	}
-	if len(f1Dict.Keys()) != 3 {
-		t.Errorf("Invalid F1 dict length 3 != %d", len(f1Dict.Keys()))
-	}
+	require.True(t, ok)
+	require.Len(t, f1Dict.Keys(), 4)
+
 	baseFont, ok := f1Dict.Get("BaseFont").(*PdfObjectName)
-	if !ok {
-		t.Error("Unable to load base font")
-	}
-	if *baseFont != "Times-Roman" {
-		t.Errorf("Invalid base font (should be Times-Roman not %s)", *baseFont)
-	}
+	require.True(t, ok)
+	require.Equal(t, "Times-Roman", baseFont.String())
 }

--- a/pdf/core/parser_test.go
+++ b/pdf/core/parser_test.go
@@ -722,10 +722,10 @@ func TestMinimalPDFFile(t *testing.T) {
 
 	require.Len(t, parser.xrefs.ObjectMap, 4)
 	require.Equal(t, 1, parser.xrefs.ObjectMap[1].ObjectNumber)
-	require.Equal(t, 18, parser.xrefs.ObjectMap[1].Offset)
+	require.Equal(t, int64(18), parser.xrefs.ObjectMap[1].Offset)
 	require.Equal(t, XrefTypeTableEntry, parser.xrefs.ObjectMap[1].XType)
 	require.Equal(t, 3, parser.xrefs.ObjectMap[3].ObjectNumber)
-	require.Equal(t, 178, parser.xrefs.ObjectMap[3].Offset)
+	require.Equal(t, int64(178), parser.xrefs.ObjectMap[3].Offset)
 	require.Equal(t, XrefTypeTableEntry, parser.xrefs.ObjectMap[3].XType)
 
 	// Check catalog object.
@@ -761,7 +761,7 @@ func TestMinimalPDFFile(t *testing.T) {
 
 	f1Dict, ok := fontDict.Get("F1").(*PdfObjectDictionary)
 	require.True(t, ok)
-	require.Len(t, f1Dict.Keys(), 4)
+	require.Len(t, f1Dict.Keys(), 3)
 
 	baseFont, ok := f1Dict.Get("BaseFont").(*PdfObjectName)
 	require.True(t, ok)

--- a/pdf/core/utils.go
+++ b/pdf/core/utils.go
@@ -39,7 +39,7 @@ func (parser *PdfParser) Inspect() (map[string]int, error) {
 // GetObjectNums returns a sorted list of object numbers of the PDF objects in the file.
 func (parser *PdfParser) GetObjectNums() []int {
 	var objNums []int
-	for _, x := range parser.xrefs {
+	for _, x := range parser.xrefs.ObjectMap {
 		objNums = append(objNums, x.ObjectNumber)
 	}
 
@@ -91,7 +91,7 @@ func resolveReferencesDeep(o PdfObject, depth int, traversed map[PdfObject]struc
 		return resolveReferencesDeep(so.PdfObjectDictionary, depth+1, traversed)
 	case *PdfObjectDictionary:
 		dict := t
-		common.Log.Trace("- dict: %s", dict)
+		//common.Log.Trace("- dict: %s", dict)
 		for _, name := range dict.Keys() {
 			v := dict.Get(name)
 			if ref, isRef := v.(*PdfObjectReference); isRef {
@@ -154,14 +154,14 @@ func (parser *PdfParser) inspect() (map[string]int, error) {
 	failedCount := 0
 
 	var keys []int
-	for k := range parser.xrefs {
+	for k := range parser.xrefs.ObjectMap {
 		keys = append(keys, k)
 	}
 	sort.Ints(keys)
 
 	i := 0
 	for _, k := range keys {
-		xref := parser.xrefs[k]
+		xref := parser.xrefs.ObjectMap[k]
 		if xref.ObjectNumber == 0 {
 			continue
 		}
@@ -248,7 +248,7 @@ func (parser *PdfParser) inspect() (map[string]int, error) {
 	}
 	common.Log.Trace("=======")
 
-	if len(parser.xrefs) < 1 {
+	if len(parser.xrefs.ObjectMap) < 1 {
 		common.Log.Debug("ERROR: This document is invalid (xref table missing!)")
 		return nil, fmt.Errorf("invalid document (xref table missing)")
 	}

--- a/pdf/core/utils.go
+++ b/pdf/core/utils.go
@@ -91,7 +91,7 @@ func resolveReferencesDeep(o PdfObject, depth int, traversed map[PdfObject]struc
 		return resolveReferencesDeep(so.PdfObjectDictionary, depth+1, traversed)
 	case *PdfObjectDictionary:
 		dict := t
-		//common.Log.Trace("- dict: %s", dict)
+		common.Log.Trace("- dict: %s", dict)
 		for _, name := range dict.Keys() {
 			v := dict.Get(name)
 			if ref, isRef := v.(*PdfObjectReference); isRef {

--- a/pdf/model/writer.go
+++ b/pdf/model/writer.go
@@ -131,8 +131,8 @@ func SetPdfTitle(title string) {
 type PdfWriter struct {
 	root        *core.PdfIndirectObject
 	pages       *core.PdfIndirectObject
-	objects     []core.PdfObject
-	objectsMap  map[core.PdfObject]bool // Quick lookup table.
+	objects     []core.PdfObject            // Objects to write.
+	objectsMap  map[core.PdfObject]struct{} // Quick lookup table.
 	writer      *bufio.Writer
 	writePos    int64 // Represents the current position within output file.
 	outlines    []*core.PdfIndirectObject
@@ -176,7 +176,7 @@ type PdfWriter struct {
 func NewPdfWriter() PdfWriter {
 	w := PdfWriter{}
 
-	w.objectsMap = map[core.PdfObject]bool{}
+	w.objectsMap = map[core.PdfObject]struct{}{}
 	w.objects = []core.PdfObject{}
 	w.pendingObjects = map[core.PdfObject]*core.PdfObjectDictionary{}
 	w.traversed = map[core.PdfObject]struct{}{}
@@ -357,13 +357,11 @@ func copyObject(obj core.PdfObject, objectToObjectCopyMap map[core.PdfObject]cor
 func (w *PdfWriter) copyObjects() {
 	objectToObjectCopyMap := make(map[core.PdfObject]core.PdfObject)
 	objects := make([]core.PdfObject, len(w.objects))
-	objectsMap := make(map[core.PdfObject]bool)
+	objectsMap := make(map[core.PdfObject]struct{}, len(w.objects))
 	for i, obj := range w.objects {
 		newObject := copyObject(obj, objectToObjectCopyMap)
 		objects[i] = newObject
-		if w.objectsMap[obj] {
-			objectsMap[newObject] = true
-		}
+		objectsMap[newObject] = struct{}{}
 	}
 
 	w.objects = objects
@@ -406,14 +404,8 @@ func (w *PdfWriter) GetOptimizer() Optimizer {
 }
 
 func (w *PdfWriter) hasObject(obj core.PdfObject) bool {
-	// Check if already added.
-	for _, o := range w.objects {
-		// TODO(gunnsth): Replace with a map to check if added - should improve performance.
-		if o == obj {
-			return true
-		}
-	}
-	return false
+	_, found := w.objectsMap[obj]
+	return found
 }
 
 // Adds the object to list of objects and returns true if the obj was
@@ -427,6 +419,7 @@ func (w *PdfWriter) addObject(obj core.PdfObject) bool {
 		}
 
 		w.objects = append(w.objects, obj)
+		w.objectsMap[obj] = struct{}{}
 		return true
 	}
 
@@ -925,6 +918,11 @@ func (w *PdfWriter) Write(writer io.Writer) error {
 		if err != nil {
 			return err
 		}
+		objMap := make(map[core.PdfObject]struct{}, len(w.objects))
+		for _, obj := range w.objects {
+			objMap[obj] = struct{}{}
+		}
+		w.objectsMap = objMap
 	}
 
 	w.writePos = w.writeOffset
@@ -963,8 +961,8 @@ func (w *PdfWriter) Write(writer io.Writer) error {
 	common.Log.Trace("Writing %d obj", len(w.objects))
 	w.crossReferenceMap = make(map[int]crossReference)
 	w.crossReferenceMap[0] = crossReference{Type: 0, ObjectNumber: 0, Generation: 0xFFFF}
-	if w.appendToXrefs != nil {
-		for idx, xref := range w.appendToXrefs {
+	if w.appendToXrefs.ObjectMap != nil {
+		for idx, xref := range w.appendToXrefs.ObjectMap {
 			if idx == 0 {
 				continue
 			}


### PR DESCRIPTION
Two notable performance enhancements:
- xrefNextObjectOffset search changed to binary search and limited to only uncompressed objects (ones with offset and not within stream).
- Speedup hasObject lookup in the writer using a map.

Changes required changing XrefTable to a struct to be able to add the cached list of objects for faster search.

The changes speed up passthrough benchmark test in the build server from 38-40seconds down to 15 seconds, so it's a pretty significant improvement.