### PR TITLE
Parser: Treat empty indirect objects as containing the null object

### DIFF
--- a/pdf/core/encoding.go
+++ b/pdf/core/encoding.go
@@ -1897,8 +1897,8 @@ func (enc *CCITTFaxEncoder) DecodeBytes(encoded []byte) ([]byte, error) {
 		EndOfBlock:             enc.EndOfBlock,
 		BlackIs1:               enc.BlackIs1,
 		DamagedRowsBeforeError: enc.DamagedRowsBeforeError,
-		Rows:             enc.Rows,
-		EncodedByteAlign: enc.EncodedByteAlign,
+		Rows:                   enc.Rows,
+		EncodedByteAlign:       enc.EncodedByteAlign,
 	}
 
 	pixels, err := encoder.Decode(encoded)
@@ -1969,8 +1969,8 @@ func (enc *CCITTFaxEncoder) EncodeBytes(data []byte) ([]byte, error) {
 		EndOfBlock:             enc.EndOfBlock,
 		BlackIs1:               enc.BlackIs1,
 		DamagedRowsBeforeError: enc.DamagedRowsBeforeError,
-		Rows:             enc.Rows,
-		EncodedByteAlign: enc.EncodedByteAlign,
+		Rows:                   enc.Rows,
+		EncodedByteAlign:       enc.EncodedByteAlign,
 	}
 
 	return encoder.Encode(pixels), nil

--- a/pdf/core/parser_test.go
+++ b/pdf/core/parser_test.go
@@ -43,16 +43,16 @@ var namePairs = map[string]string{
 	"/Name1":                             "Name1",
 	"/ASomewhatLongerName":               "ASomewhatLongerName",
 	"/A;Name_With-Various***Characters?": "A;Name_With-Various***Characters?",
-	"/1.2":                     "1.2",
-	"/$$":                      "$$",
-	"/@pattern":                "@pattern",
-	"/.notdef":                 ".notdef",
-	"/Lime#20Green":            "Lime Green",
-	"/paired#28#29parentheses": "paired()parentheses",
-	"/The_Key_of_F#23_Minor":   "The_Key_of_F#_Minor",
-	"/A#42":                    "AB",
-	"/":                        "",
-	"/ ":                       "",
+	"/1.2":                               "1.2",
+	"/$$":                                "$$",
+	"/@pattern":                          "@pattern",
+	"/.notdef":                           ".notdef",
+	"/Lime#20Green":                      "Lime Green",
+	"/paired#28#29parentheses":           "paired()parentheses",
+	"/The_Key_of_F#23_Minor":             "The_Key_of_F#_Minor",
+	"/A#42":                              "AB",
+	"/":                                  "",
+	"/ ":                                 "",
 	"/#3CBC88#3E#3CC5ED#3E#3CD544#3E#3CC694#3E": "<BC88><C5ED><D544><C694>",
 }
 
@@ -134,18 +134,18 @@ func BenchmarkStringParsing(b *testing.B) {
 }
 
 var stringPairs = map[string]string{
-	"(This is a string)":                                                                        "This is a string",
-	"(Strings may contain\n newlines and such)":                                                 "Strings may contain\n newlines and such",
+	"(This is a string)":                        "This is a string",
+	"(Strings may contain\n newlines and such)": "Strings may contain\n newlines and such",
 	"(Strings may contain balanced parenthesis () and\nspecial characters (*!&}^% and so on).)": "Strings may contain balanced parenthesis () and\nspecial characters (*!&}^% and so on).",
 	"(These \\\ntwo strings \\\nare the same.)":                                                 "These two strings are the same.",
 	"(These two strings are the same.)":                                                         "These two strings are the same.",
-	"(\\\\)": "\\",
-	"(This string has an end-of-line at the end of it.\n)": "This string has an end-of-line at the end of it.\n",
-	"(So does this one.\\n)":                               "So does this one.\n",
-	"(\\0053)":                                             "\0053",
-	"(\\53)":                                               "\053",
-	"(\\053)":                                              "+",
-	"(\\53\\101)":                                          "+A",
+	"(\\\\)":                                                                                    "\\",
+	"(This string has an end-of-line at the end of it.\n)":                                      "This string has an end-of-line at the end of it.\n",
+	"(So does this one.\\n)":                                                                    "So does this one.\n",
+	"(\\0053)":                                                                                  "\0053",
+	"(\\53)":                                                                                    "\053",
+	"(\\053)":                                                                                   "+",
+	"(\\53\\101)":                                                                               "+A",
 }
 
 func TestStringParsing(t *testing.T) {
@@ -807,8 +807,8 @@ func TestPDFVersionParse(t *testing.T) {
 	defer f1.Close()
 
 	parser := &PdfParser{
-		rs:       f1,
-		ObjCache: make(objectCache),
+		rs:                                    f1,
+		ObjCache:                              make(objectCache),
 		streamLengthReferenceLookupInProgress: map[int64]bool{},
 	}
 
@@ -831,8 +831,8 @@ func TestPDFVersionParse(t *testing.T) {
 	defer f2.Close()
 
 	parser = &PdfParser{
-		rs:       f2,
-		ObjCache: make(objectCache),
+		rs:                                    f2,
+		ObjCache:                              make(objectCache),
 		streamLengthReferenceLookupInProgress: map[int64]bool{},
 	}
 

--- a/pdf/model/writer.go
+++ b/pdf/model/writer.go
@@ -689,6 +689,10 @@ func (w *PdfWriter) writeObject(num int, obj core.PdfObject) {
 		if sDict, ok := pobj.PdfObject.(*pdfSignDictionary); ok {
 			sDict.fileOffset = w.writePos + int64(len(outStr))
 		}
+		if pobj.PdfObject == nil {
+			common.Log.Debug("Error: indirect object's PdfObject should never be nil - setting to PdfObjectNull")
+			pobj.PdfObject = core.MakeNull()
+		}
 		outStr += pobj.PdfObject.WriteString()
 		outStr += "\nendobj\n"
 		w.writeString(outStr)


### PR DESCRIPTION
Addresses #445 . Currently empty objects are parsed as *PdfIndirectObject with an inner object (PdfObject) as nil. This can cause errors down the line.

Such an empty indirect object is not technically valid but still appears out in the wild. It should be safe to treat these as null objects and output an incompatibility warning.

In addition, this PR checks for the nil object when writing out and sets it.  Thus the safeguarding is done both on parsing and writing out.

This PR also updates `ParseIndirectObject` to enable handling of short objects. Previously an EOF error was returned if less than 20 bytes in length and the parsing not finished.