### PR TITLE
Search xref objects with tolerance both to the left and right

### DIFF
--- a/pdf/core/io.go
+++ b/pdf/core/io.go
@@ -83,6 +83,10 @@ func (parser *PdfParser) GetFileOffset() int64 {
 
 // SetFileOffset sets the file to an offset position and resets buffer.
 func (parser *PdfParser) SetFileOffset(offset int64) {
+	if offset < 0 {
+		offset = 0
+	}
+
 	parser.rs.Seek(offset, io.SeekStart)
 	parser.reader = bufio.NewReader(parser.rs)
 }

--- a/pdf/core/parser.go
+++ b/pdf/core/parser.go
@@ -1109,8 +1109,15 @@ func (parser *PdfParser) parseXref() (*PdfObjectDictionary, error) {
 	var err error
 	var trailerDict *PdfObjectDictionary
 
+	// Peek 20 bytes to the left and 20 bytes to the right of
+	// the current offset. Reset to the original offset after reading.
+	const tolerance = 20
+	offset := parser.GetFileOffset()
+	parser.SetFileOffset(offset - tolerance)
+	bb, _ := parser.reader.Peek(2 * tolerance)
+	parser.SetFileOffset(offset)
+
 	// Points to xref table or xref stream object?
-	bb, _ := parser.reader.Peek(20)
 	if reIndirectObject.MatchString(string(bb)) {
 		common.Log.Trace("xref points to an object.  Probably xref object")
 		common.Log.Trace("starting with \"%s\"", string(bb))

--- a/pdf/core/parser.go
+++ b/pdf/core/parser.go
@@ -1106,6 +1106,10 @@ func (parser *PdfParser) parseXrefStream(xstm *PdfObjectInteger) (*PdfObjectDict
 // Parse xref table at the current file position. Can either be a standard xref
 // table, or an xref stream.
 func (parser *PdfParser) parseXref() (*PdfObjectDictionary, error) {
+	// Search xrefs within 20 bytes of the current location. If the first
+	// iteration of the loop is unable to find a match, peek another 20 bytes
+	// left of the current location, add them to the previously read buffer
+	// and try again.
 	const bufLen = 20
 	bb, _ := parser.reader.Peek(bufLen)
 	for i := 0; i < 2; i++ {


### PR DESCRIPTION
Search for xref objects on both directions with 20 bytes tolerance.
Reset to the current offset after reading the content.

Addresses #433 