### PR TITLE
V3: Detect and fix stride offsets in loaded go images

### DIFF
--- a/pdf/model/image.go
+++ b/pdf/model/image.go
@@ -250,9 +250,9 @@ func (ih DefaultImageHandler) NewImageFromGoImage(goimg goimage.Image) (*Image, 
 	default:
 		// Speed up jpeg encoding by converting to RGBA first.
 		// Will not be required once the golang image/jpeg package is optimized.
-		b = goimage.Rect(0, 0, b.Dx(), b.Dy())
-		m = goimage.NewRGBA(b)
-		draw.Draw(m, b, goimg, b.Min, draw.Src)
+		m = goimage.NewRGBA(goimage.Rect(0, 0, b.Dx(), b.Dy()))
+		draw.Draw(m, m.Bounds(), goimg, b.Min, draw.Src)
+		b = m.Bounds()
 	}
 
 	numPixels := b.Dx() * b.Dy()

--- a/pdf/model/image.go
+++ b/pdf/model/image.go
@@ -250,8 +250,9 @@ func (ih DefaultImageHandler) NewImageFromGoImage(goimg goimage.Image) (*Image, 
 	default:
 		// Speed up jpeg encoding by converting to RGBA first.
 		// Will not be required once the golang image/jpeg package is optimized.
-		m = goimage.NewRGBA(goimage.Rect(0, 0, b.Dx(), b.Dy()))
-		draw.Draw(m, m.Bounds(), goimg, b.Min, draw.Src)
+		b = goimage.Rect(0, 0, b.Dx(), b.Dy())
+		m = goimage.NewRGBA(b)
+		draw.Draw(m, b, goimg, b.Min, draw.Src)
 	}
 
 	numPixels := b.Dx() * b.Dy()

--- a/pdf/model/image_test.go
+++ b/pdf/model/image_test.go
@@ -6,6 +6,9 @@
 package model
 
 import (
+	"image"
+	"image/color"
+	"image/draw"
 	"testing"
 )
 
@@ -62,5 +65,80 @@ func TestImageResampling(t *testing.T) {
 	}
 	if img.Data[1] != 64 {
 		t.Errorf("Value != 64 (%d)", img.Data[1])
+	}
+}
+
+func makeTestImage(x, y int, val byte) *image.RGBA {
+	rect := image.Rect(0, 0, x, y)
+	m := image.NewRGBA(rect)
+
+	for i := 0; i < x; i++ {
+		for j := 0; j < y; j++ {
+			rgba := color.RGBA{R: val, G: val, B: val, A: 0}
+			m.Set(i, j, rgba)
+		}
+	}
+	return m
+}
+
+func BenchmarkImageCopyingDraw(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img := makeTestImage(100, 100, byte(n))
+		b := img.Bounds()
+		m := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
+
+		// Image copying using draw.Draw.
+		draw.Draw(m, img.Bounds(), img, b.Min, draw.Src)
+	}
+}
+
+func BenchmarkImageCopyingAtSet(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img := makeTestImage(100, 100, byte(n))
+		b := img.Bounds()
+		m := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
+
+		// Image copying with At and direct set.
+		for x := m.Rect.Min.X; x < m.Rect.Max.X; x++ {
+			for y := m.Rect.Min.Y; y < m.Rect.Max.Y; y++ {
+				m.Set(x, y, img.At(x, y))
+			}
+		}
+	}
+}
+
+func BenchmarkImageCopyingAtDirectSet(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img := makeTestImage(100, 100, byte(n))
+		b := img.Bounds()
+		m := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
+
+		// Image copying with At to get colors and set Pix directly.
+		i := 0
+		for x := m.Rect.Min.X; x < m.Rect.Max.X; x++ {
+			for y := m.Rect.Min.Y; y < m.Rect.Max.Y; y++ {
+				r, g, b, a := img.At(x, y).RGBA()
+
+				m.Pix[4*i], m.Pix[4*i+1], m.Pix[4*i+2], m.Pix[4*i+3] = byte(r), byte(g), byte(b), byte(a)
+				i++
+			}
+		}
+	}
+}
+
+func BenchmarkImageCopyingDirect(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		img := makeTestImage(100, 100, byte(n))
+		b := img.Bounds()
+		m := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
+
+		// Image copying with direct Pix access for getting and setting.
+		i := 0
+		for x := m.Rect.Min.X; x < m.Rect.Max.X; x++ {
+			for y := m.Rect.Min.Y; y < m.Rect.Max.Y; y++ {
+				m.Pix[4*i], m.Pix[4*i+1], m.Pix[4*i+2], m.Pix[4*i+3] = img.Pix[4*i], img.Pix[4*i+1], img.Pix[4*i+2], img.Pix[4*i+3]
+				i++
+			}
+		}
 	}
 }


### PR DESCRIPTION
Addresses #444 .
The problem is that loaded Go images have a data buffer that is not always of the same format, there can be extra bytes at the end of each line (image.Stride != bytesPerPixel*pixelsPerLine).
This was assumed to be the case, but was not, leading to some offsets building up and image distortion.

This PR addresses the problem by redrawing the images onto a "canvas" of the right size such that the new image has the right format. The drawback is that redrawing the image means that the image is loaded into memory twice so that doubles the memory use as a result (and obviously takes more time too).

The alternative approach would have been to alter model.Image to have a Stride parameter similarly to the original go image.  That would require a lot more changes in internal data handling for images so was not the preferred course of action.