### PR TITLE
Creator: Benchmark for paragraph adding

### DIFF
--- a/pdf/creator/block.go
+++ b/pdf/creator/block.go
@@ -266,6 +266,11 @@ func (blk *Block) translate(tx, ty float64) {
 // drawToPage draws the block on a PdfPage. Generates the content streams and appends to the PdfPage's content
 // stream and links needed resources.
 func (blk *Block) drawToPage(page *model.PdfPage) error {
+
+	// TODO(gunnsth): Appears very wasteful to do this all the time.
+	//        Possibly create another wrapper around model.PdfPage (creator.page) which can keep track of whether
+	//        this has already been done.
+
 	// Check if Page contents are wrapped - if not wrap it.
 	content, err := page.GetAllContentStreams()
 	if err != nil {
@@ -373,6 +378,10 @@ func (blk *Block) mergeBlocks(toAdd *Block) error {
 // Active in the sense that it modified the input contents and resources.
 func mergeContents(contents *contentstream.ContentStreamOperations, resources *model.PdfPageResources,
 	contentsToAdd *contentstream.ContentStreamOperations, resourcesToAdd *model.PdfPageResources) error {
+
+	// TODO(gunnsth): It seems rather expensive to mergeContents all the time. A lot of repetition.
+	//    It would be more efficient to perform the merge at the very and when we have all the "blocks"
+	//    for each page.
 
 	// To properly add contents from a block, we need to handle the resources that the block is
 	// using and make sure it is accessible in the modified Page.

--- a/pdf/creator/paragraph_test.go
+++ b/pdf/creator/paragraph_test.go
@@ -1,0 +1,35 @@
+/*
+ * This file is subject to the terms and conditions defined in
+ * file 'LICENSE.md', which is part of this source code package.
+ */
+
+package creator
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func benchmarkParagraphAdding(b *testing.B, loops int) {
+	for n := 0; n < b.N; n++ {
+		c := New()
+		for i := 0; i < loops; i++ {
+			p := c.NewParagraph(fmt.Sprintf("Paragraph %d - %d", n, i))
+			err := c.Draw(p)
+			require.NoError(b, err)
+		}
+
+		var buf bytes.Buffer
+		err := c.Write(&buf)
+		require.NoError(b, err)
+	}
+}
+
+// Benchmark adding multiple paragraphs and writing out.
+// Check the effects of varying number of paragraphs written out.
+func BenchmarkParagraphAdding1(b *testing.B)   { benchmarkParagraphAdding(b, 1) }
+func BenchmarkParagraphAdding10(b *testing.B)  { benchmarkParagraphAdding(b, 10) }
+func BenchmarkParagraphAdding100(b *testing.B) { benchmarkParagraphAdding(b, 100) }


### PR DESCRIPTION
Demonstrates issue #139. Couple of TODO comments to where things appear to be slow.

Results:
```
pkg: github.com/unidoc/unidoc/pdf/creator
BenchmarkParagraphAdding1-8             Unlicensed copy of unidoc
    2000            878991 ns/op
BenchmarkParagraphAdding10-8            Unlicensed copy of unidoc
     300           6307502 ns/op
BenchmarkParagraphAdding100-8           Unlicensed copy of unidoc
      10         103607560 ns/op
PASS
ok      github.com/unidoc/unidoc/pdf/creator    5.440s
```
Very slow and seems to get worse with increasing number of paragraphs.

Also did some profiling of code that added many paragraphs (5000).  That took a few minutes to process.

The profiling output (top 100) below indicates a lot of work being spent in processing the contents.
This is probably because a lot of repetition happening when merging blocks such as wrapping page content streams etc.  Added a couple of comments pointing to those issues.

The fix for this probably involves something like keeping track of whether the contents have been wrapped already and only doing when needed.  Also when merging page resources, need to have a way of doing that quicker.

```
(pprof) top100
Showing nodes accounting for 391.64s, 83.76% of 467.56s total
Dropped 517 nodes (cum <= 2.34s)
Showing top 100 nodes out of 126
      flat  flat%   sum%        cum   cum%
    57.08s 12.21% 12.21%    150.56s 32.20%  runtime.mallocgc
    41.73s  8.93% 21.13%     82.14s 17.57%  runtime.scanobject
    18.13s  3.88% 25.01%     26.82s  5.74%  runtime.heapBitsSetType
    17.80s  3.81% 28.82%     20.70s  4.43%  compress/flate.(*compressor).findMatch
    17.19s  3.68% 32.49%     17.19s  3.68%  runtime.nextFreeFast
    16.55s  3.54% 36.03%     21.26s  4.55%  runtime.findObject
    15.48s  3.31% 39.34%    130.43s 27.90%  github.com/unidoc/unidoc/pdf/contentstream.(*ContentStreamParser).parseNumber
    14.41s  3.08% 42.43%     39.18s  8.38%  compress/flate.(*compressor).deflate
    13.52s  2.89% 45.32%     13.52s  2.89%  runtime.memmove
    12.84s  2.75% 48.06%     14.18s  3.03%  bufio.(*Reader).Peek
    12.63s  2.70% 50.77%     12.63s  2.70%  runtime.memclrNoHeapPointers
    12.11s  2.59% 53.36%     37.98s  8.12%  runtime.concatstrings
    10.38s  2.22% 55.58%    231.49s 49.51%  github.com/unidoc/unidoc/pdf/contentstream.(*ContentStreamParser).parseObject
     9.33s  2.00% 57.57%     15.49s  3.31%  runtime.greyobject
     9.09s  1.94% 59.52%     46.56s  9.96%  github.com/unidoc/unidoc/pdf/contentstream.(*ContentStreamOperations).Bytes
     8.35s  1.79% 61.30%      8.35s  1.79%  runtime.acquirem
     5.58s  1.19% 62.49%     68.48s 14.65%  runtime.newobject
     5.37s  1.15% 63.64%     10.08s  2.16%  runtime.heapBitsForAddr
     5.34s  1.14% 64.79%      5.34s  1.14%  runtime.releasem
     5.15s  1.10% 65.89%      5.20s  1.11%  bufio.(*Reader).ReadByte
     4.77s  1.02% 66.91%     45.03s  9.63%  runtime.convTstring
     4.40s  0.94% 67.85%      4.40s  0.94%  runtime.arenaIndex
     4.37s  0.93% 68.78%     24.40s  5.22%  runtime.growslice
     4.23s   0.9% 69.69%      5.43s  1.16%  runtime.spanOf
     4.08s  0.87% 70.56%      5.93s  1.27%  strconv.(*extFloat).ShortestDecimal
     3.92s  0.84% 71.40%      3.92s  0.84%  runtime.cgocall
     3.34s  0.71% 72.11%    263.89s 56.44%  github.com/unidoc/unidoc/pdf/contentstream.(*ContentStreamParser).Parse
     3.09s  0.66% 72.77%      3.09s  0.66%  strconv.readFloat
     2.81s   0.6% 73.37%      2.81s   0.6%  compress/flate.matchLen
     2.71s  0.58% 73.95%     16.78s  3.59%  runtime.slicebytetostring
     2.57s  0.55% 74.50%     19.45s  4.16%  runtime.rawstringtmp
     2.53s  0.54% 75.04%     87.26s 18.66%  runtime.gcDrain
     2.50s  0.53% 75.58%      8.55s  1.83%  github.com/unidoc/unidoc/pdf/contentstream.(*ContentStreamParser).skipSpaces
     2.45s  0.52% 76.10%      7.14s  1.53%  bytes.(*Buffer).WriteString
     2.42s  0.52% 76.62%     20.80s  4.45%  github.com/unidoc/unidoc/pdf/contentstream.(*ContentStreamParser).parseOperand
     2.32s   0.5% 77.12%      4.10s  0.88%  github.com/unidoc/unidoc/pdf/core.(*PdfObjectName).WriteString
     2.15s  0.46% 77.58%     40.13s  8.58%  runtime.concatstring2
     2.15s  0.46% 78.04%     16.87s  3.61%  runtime.rawstring
     1.92s  0.41% 78.45%      3.94s  0.84%  runtime.gcmarknewobject
     1.89s   0.4% 78.85%      4.06s  0.87%  runtime.mapassign
     1.65s  0.35% 79.20%      2.77s  0.59%  strconv.ParseInt
     1.58s  0.34% 79.54%     12.05s  2.58%  runtime.(*mcentral).cacheSpan
     1.54s  0.33% 79.87%     14.96s  3.20%  github.com/unidoc/unidoc/pdf/core.(*PdfObjectFloat).WriteString
     1.51s  0.32% 80.20%      6.20s  1.33%  runtime.sweepone
     1.16s  0.25% 80.44%      3.40s  0.73%  runtime.gcWriteBarrier
     1.13s  0.24% 80.68%      7.89s  1.69%  strconv.atof64
     1.07s  0.23% 80.91%      9.15s  1.96%  strconv.genericFtoa
     1.06s  0.23% 81.14%      5.15s  1.10%  github.com/unidoc/unidoc/pdf/contentstream.(*ContentStreamParser).parseName
     1.05s  0.22% 81.36%      2.42s  0.52%  compress/flate.(*huffmanBitWriter).writeTokens
     0.96s  0.21% 81.57%         4s  0.86%  compress/flate.(*decompressor).huffmanBlock
     0.78s  0.17% 81.74%      3.04s  0.65%  runtime.wbBufFlush1
     0.77s  0.16% 81.90%      9.31s  1.99%  github.com/unidoc/unidoc/pdf/contentstream.(*ContentStreamParser).parseArray
     0.77s  0.16% 82.07%     15.12s  3.23%  runtime.(*mcache).nextFree
     0.67s  0.14% 82.21%      6.92s  1.48%  github.com/unidoc/unidoc/pdf/core.(*PdfObjectString).WriteString
     0.65s  0.14% 82.35%      2.56s  0.55%  runtime.gentraceback
     0.64s  0.14% 82.49%      2.40s  0.51%  github.com/unidoc/unidoc/pdf/contentstream.(*ContentStreamParser).parseString
     0.59s  0.13% 82.61%      5.29s  1.13%  runtime.schedule
     0.58s  0.12% 82.74%      8.98s  1.92%  github.com/unidoc/unidoc/pdf/core.MakeString
     0.58s  0.12% 82.86%      4.56s  0.98%  runtime.(*mspan).sweep
     0.53s  0.11% 82.97%      9.03s  1.93%  github.com/unidoc/unidoc/pdf/core.(*PdfObjectArray).WriteString
     0.51s  0.11% 83.08%     12.56s  2.69%  runtime.(*mcache).refill
     0.40s 0.086% 83.17%      8.29s  1.77%  strconv.ParseFloat
     0.34s 0.073% 83.24%    103.58s 22.15%  runtime.systemstack
     0.28s  0.06% 83.30%      2.98s  0.64%  runtime.(*mheap).allocSpanLocked
     0.28s  0.06% 83.36%     13.42s  2.87%  strconv.FormatFloat
     0.24s 0.051% 83.41%      5.42s  1.16%  runtime.makeslice
     0.24s 0.051% 83.46%      3.78s  0.81%  runtime.newstack
     0.17s 0.036% 83.50%      3.87s  0.83%  bytes.(*Buffer).grow
     0.16s 0.034% 83.53%      8.32s  1.78%  runtime.(*mcentral).grow
     0.14s  0.03% 83.56%      3.83s  0.82%  runtime.(*mheap).alloc_m
     0.13s 0.028% 83.59%      4.92s  1.05%  runtime.goschedImpl
     0.11s 0.024% 83.61%      9.78s  2.09%  runtime.(*mheap).alloc
     0.10s 0.021% 83.64%     87.88s 18.80%  runtime.gcBgMarkWorker
     0.10s 0.021% 83.66%      3.17s  0.68%  runtime.mcall
     0.07s 0.015% 83.67%      2.90s  0.62%  runtime.morestack
     0.06s 0.013% 83.69%      6.33s  1.35%  runtime.bgsweep
     0.06s 0.013% 83.70%      3.24s  0.69%  runtime.gopreempt_m
     0.04s 0.0086% 83.71%      2.45s  0.52%  runtime.gcDrainN
     0.04s 0.0086% 83.72%      2.94s  0.63%  runtime.wbBufFlush
     0.02s 0.0043% 83.72%      3.39s  0.73%  compress/flate.(*huffmanBitWriter).writeBlock
     0.02s 0.0043% 83.72%    361.26s 77.26%  github.com/unidoc/unidoc/pdf/creator.(*Block).drawToPage
     0.02s 0.0043% 83.73%      3.85s  0.82%  runtime.(*mheap).alloc.func1
     0.02s 0.0043% 83.73%      2.96s  0.63%  runtime.largeAlloc
     0.02s 0.0043% 83.74%      2.98s  0.64%  runtime.mallocgc.func1
     0.02s 0.0043% 83.74%      3.36s  0.72%  runtime.markroot
     0.02s 0.0043% 83.75%      2.90s  0.62%  runtime.wbBufFlush.func1
     0.01s 0.0021% 83.75%     35.76s  7.65%  compress/flate.(*compressor).write
     0.01s 0.0021% 83.75%      3.40s  0.73%  compress/flate.(*compressor).writeBlock
     0.01s 0.0021% 83.75%      4.21s   0.9%  compress/flate.(*decompressor).Read
     0.01s 0.0021% 83.75%      3.75s   0.8%  compress/zlib.(*Writer).Close
     0.01s 0.0021% 83.76%      3.99s  0.85%  github.com/unidoc/unidoc/pdf/contentstream.(*ContentStreamProcessor).Process
     0.01s 0.0021% 83.76%      2.52s  0.54%  runtime.gcAssistAlloc
     0.01s 0.0021% 83.76%      2.51s  0.54%  runtime.gcAssistAlloc1
     0.01s 0.0021% 83.76%     87.29s 18.67%  runtime.gcBgMarkWorker.func2
         0     0% 83.76%      5.80s  1.24%  bytes.(*Buffer).ReadFrom
         0     0% 83.76%      3.74s   0.8%  compress/flate.(*Writer).Close
         0     0% 83.76%     35.76s  7.65%  compress/flate.(*Writer).Write
         0     0% 83.76%      3.74s   0.8%  compress/flate.(*compressor).close
         0     0% 83.76%     37.73s  8.07%  compress/zlib.(*Writer).Write
         0     0% 83.76%      4.83s  1.03%  compress/zlib.(*reader).Read
```